### PR TITLE
Change to_c_repr() to with_c_repr()

### DIFF
--- a/src/ffi/list.rs
+++ b/src/ffi/list.rs
@@ -24,8 +24,7 @@ impl List {
   }
 
   pub fn push_str(&mut self, val: &str) {
-    let c_val = val.to_c_str();
-    self.push_bytes(c_val.as_bytes());
+    self.push_bytes(val.as_bytes());
   }
 
   pub fn push_bytes(&mut self, val: &[u8]) {
@@ -53,7 +52,7 @@ impl Drop for List {
 }
 
 impl<'a> OptVal for &'a List {
-  fn to_c_repr(self) -> *c_void {
-    unsafe { mem::transmute(self.head) }
+  fn with_c_repr(self, f: |*c_void|) {
+    f(self.head as *c_void)
   }
 }

--- a/src/ffi/opt.rs
+++ b/src/ffi/opt.rs
@@ -9,34 +9,30 @@ static OFF_T: c_int         = 30_000;
 pub type Opt = c_int;
 
 pub trait OptVal {
-  fn to_c_repr(self) -> *c_void;
+  fn with_c_repr(self, f: |*c_void|);
 }
 
 impl OptVal for int {
-  fn to_c_repr(self) -> *c_void {
-    unsafe { mem::transmute(self) }
+  fn with_c_repr(self, f: |*c_void|) {
+    f(self as *c_void)
   }
 }
 
 impl OptVal for uint {
-  fn to_c_repr(self) -> *c_void {
-    unsafe { mem::transmute(self) }
+  fn with_c_repr(self, f: |*c_void|) {
+    f(self as *c_void)
   }
 }
 
 impl OptVal for bool {
-  fn to_c_repr(self) -> *c_void {
-    if self {
-      1u.to_c_repr()
-    } else {
-      0u.to_c_repr()
-    }
+  fn with_c_repr(self, f: |*c_void|) {
+      f(self as uint as *c_void)
   }
 }
 
 impl<'a> OptVal for &'a str {
-  fn to_c_repr(self) -> *c_void {
-    self.to_c_str().as_bytes().as_ptr() as *c_void
+  fn with_c_repr(self, f: |*c_void|) {
+    self.with_c_str(|arg| f(arg as *c_void))
   }
 }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -20,7 +20,13 @@ impl Handle {
   #[inline]
   pub fn setopt<T: opt::OptVal>(&mut self, option: opt::Opt, val: T) -> Result<(), err::ErrCode> {
     // TODO: Prevent setting callback related options
-    let res = unsafe { easy::curl_easy_setopt(self.curl, option, val.to_c_repr()) };
+    let mut res = err::OK;
+    unsafe {
+        val.with_c_repr(|repr| {
+            res = easy::curl_easy_setopt(self.curl, option, repr);
+        })
+    }
+    println!("{} = {}", option, res);
     if res.is_success() { Ok(()) } else { Err(res) }
   }
 
@@ -50,6 +56,7 @@ impl Handle {
 
     // If the request failed, abort here
     if !err.is_success() {
+        println!("oh no {}", err);
       return Err(err);
     }
 


### PR DESCRIPTION
This prevents a use-after-free in curl when passing C strings to curl.
