### PR TITLE
Make Request::new public

### DIFF
--- a/src/http/handle.rs
+++ b/src/http/handle.rs
@@ -107,7 +107,7 @@ enum BodyType {
 }
 
 impl<'a, 'b> Request<'a, 'b> {
-    fn new<'a, 'b>(handle: &'a mut Handle, method: Method) -> Request<'a, 'b> {
+    pub fn new<'a, 'b>(handle: &'a mut Handle, method: Method) -> Request<'a, 'b> {
         Request {
             err: None,
             handle: handle,


### PR DESCRIPTION
I'm writing a library for the Hue api ( http://github.com/mcpherrinm/hue/ ) using curl-rust.

I'd like Request::new to be public so that I can write a higher level abstraction over HTTP that still takes a Method as input.  The existing way to create a request is with a get/put/post/delete/etc function call on a Handle, but that means I have to do a match on my enum and call the right method, which all just ends up calling Request::new.  I'd like to call it directly.
