### PR TITLE
Added imports for alternatives to an enum

### DIFF
--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -68,7 +68,7 @@ pub const CURLOPTTYPE_OBJECTPOINT: c_int   = 10_000;
 pub const CURLOPTTYPE_FUNCTIONPOINT: c_int = 20_000;
 pub const CURLOPTTYPE_OFF_T: c_int         = 30_000;
 
-pub const CURL_VERSION_NOW: CURLversion    = CURL_VERSION_FOURTH;
+pub const CURL_VERSION_NOW: CURLversion    = CURLversion::CURL_VERSION_FOURTH;
 pub const CURL_VERSION_IPV6:         c_int = (1 << 0);
 pub const CURL_VERSION_KERBEROS4:    c_int = (1 << 1);
 pub const CURL_VERSION_SSL:          c_int = (1 << 2);

--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -1,5 +1,7 @@
 use std::io::{BufReader,IoResult,Reader};
 
+use self::Body::{FixedBody, ChunkedBody};
+
 pub enum Body<'a> {
     FixedBody(BufReader<'a>, uint),
     ChunkedBody(&'a mut Reader+'a)

--- a/src/http/handle.rs
+++ b/src/http/handle.rs
@@ -9,6 +9,9 @@ use http::Response;
 use http::body::{Body,ToBody};
 use {ProgressCb,ErrCode};
 
+use self::Method::{Get, Head, Post, Put, Delete};
+use self::BodyType::{Fixed, Chunked};
+
 static DEFAULT_TIMEOUT_MS: uint = 30_000;
 
 pub struct Handle {

--- a/src/http/header.rs
+++ b/src/http/header.rs
@@ -1,5 +1,8 @@
 use std::str;
 
+use self::State::{HdrNameStart, HdrName, HdrValStart, HdrNameDiscardWs, HdrVal,
+                  HdrValDiscardWs};
+
 enum State {
     HdrNameStart,
     HdrName,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -12,15 +12,15 @@ macro_rules! ops(
 )
 
 macro_rules! send(
-    ($e:expr) => (server::SendBytes($e));
+    ($e:expr) => (server::Op::SendBytes($e));
 )
 
 macro_rules! recv(
-    ($e:expr) => (server::ReceiveBytes($e));
+    ($e:expr) => (server::Op::ReceiveBytes($e));
 )
 
 macro_rules! wait(
-    ($dur:expr) => (server::Wait($dur));
+    ($dur:expr) => (server::Op::Wait($dur));
 )
 
 mod get;

--- a/src/test/server.rs
+++ b/src/test/server.rs
@@ -6,6 +6,8 @@ use std::io::{Acceptor, Listener};
 use std::str;
 use std::time::Duration;
 
+use self::Op::{SendBytes, ReceiveBytes, Wait, Shutdown};
+
 // Global handle to the running test HTTP server
 local_data_key!(handle: Handle)
 


### PR DESCRIPTION
[This push](https://github.com/rust-lang/rust/pull/18973) breaks `master`.  This pull request fixes this.
