### PR TITLE
Renamed function call as per a deprecation warning.

### DIFF
--- a/src/ffi/err.rs
+++ b/src/ffi/err.rs
@@ -123,6 +123,6 @@ impl fmt::Show for ErrCode {
 impl error::Error for ErrCode {
     fn description(&self) -> &str {
         let code = self.code();
-        unsafe { str::raw::c_str_to_static_slice(ffi::curl_easy_strerror(code)) }
+        unsafe { str::from_c_str(ffi::curl_easy_strerror(code)) }
     }
 }


### PR DESCRIPTION
`str::raw::c_str_to_static_slice` has been renamed to `str::from_c_str`.
