### PR TITLE
Don't set a default whole request timeout.

### DIFF
--- a/src/http/handle.rs
+++ b/src/http/handle.rs
@@ -21,7 +21,6 @@ pub struct Handle {
 impl Handle {
     pub fn new() -> Handle {
         return configure(Handle { easy: Easy::new() }
-            .timeout(DEFAULT_TIMEOUT_MS)
             .connect_timeout(DEFAULT_TIMEOUT_MS));
 
         #[cfg(unix)]


### PR DESCRIPTION
I don't think a binding should set such a low value (or any value) by default.

http://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT_MS.html