### PR TITLE
Make sure that the argument of str::from_c_str is always of the right type

### DIFF
--- a/src/ffi/err.rs
+++ b/src/ffi/err.rs
@@ -124,6 +124,6 @@ impl fmt::Show for ErrCode {
 impl error::Error for ErrCode {
     fn description(&self) -> &str {
         let code = self.code();
-        unsafe { str::from_c_str(ffi::curl_easy_strerror(code)) }
+        unsafe { str::from_c_str(ffi::curl_easy_strerror(code) as *const _) }
     }
 }


### PR DESCRIPTION
Fixes #42 
