### PR TITLE
Make response body optional

### DIFF
--- a/src/http/handle.rs
+++ b/src/http/handle.rs
@@ -288,6 +288,7 @@ impl<'a, 'b> Request<'a, 'b> {
             ..
         } = self;
 
+        let mut allow_null_body = false;
         if follow {
             try!(handle.easy.setopt(opt::FOLLOWLOCATION, 1));
         }
@@ -302,7 +303,10 @@ impl<'a, 'b> Request<'a, 'b> {
 
         match method {
             Get => try!(handle.easy.setopt(opt::HTTPGET, 1)),
-            Head => try!(handle.easy.setopt(opt::NOBODY, 1)),
+            Head => {
+                allow_null_body = true;
+                try!(handle.easy.setopt(opt::NOBODY, 1));
+            }
             Post => try!(handle.easy.setopt(opt::POST, 1)),
             Put => try!(handle.easy.setopt(opt::UPLOAD, 1)),
             Patch => {
@@ -377,7 +381,7 @@ impl<'a, 'b> Request<'a, 'b> {
             try!(handle.easy.setopt(opt::HTTPHEADER, &ffi_headers));
         }
 
-        handle.easy.perform(body.as_mut(), progress)
+        handle.easy.perform(body.as_mut(), allow_null_body, progress)
     }
 }
 

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -2,16 +2,20 @@ use std::{fmt,str};
 use std::collections::HashMap;
 
 pub type Headers = HashMap<String, Vec<String>>;
+pub type ResponseBody = Option<Vec<u8>>;
 
 #[derive(Debug)]
 pub struct Response {
     code: u32,
     hdrs: Headers,
-    body: Vec<u8>
+    body: ResponseBody
 }
 
 impl Response {
-    pub fn new(code: u32, hdrs: Headers, body: Vec<u8>) -> Response {
+    pub fn new(code: u32, hdrs: Headers, mut body: ResponseBody, allow_null_body: bool) -> Response {
+        if !allow_null_body && body.is_none(){
+            body = Some(Vec::new())
+        }
         Response {
             code: code,
             hdrs: hdrs,
@@ -34,11 +38,11 @@ impl Response {
             .unwrap_or(&[])
     }
 
-    pub fn get_body<'a>(&'a self) -> &'a [u8] {
+    pub fn get_body<'a>(&'a self) -> &ResponseBody {
         &self.body
     }
 
-    pub fn move_body(self) -> Vec<u8> {
+    pub fn move_body(self) -> ResponseBody {
         self.body
     }
 }
@@ -51,9 +55,12 @@ impl fmt::Display for Response {
             try!(write!(fmt, "{}: {}, ", name, val.connect(", ")));
         }
 
-        match str::from_utf8(&self.body) {
-            Ok(b) => try!(write!(fmt, "{}", b)),
-            Err(..) => try!(write!(fmt, "bytes[{}]", self.body.len()))
+        match self.body {
+            Some(ref body) => match str::from_utf8(&body) {
+                Ok(b) => try!(write!(fmt, "{}", b)),
+                Err(..) => try!(write!(fmt, "bytes[{}]", body.len()))
+            },
+            None => try!(write!(fmt, "NoBody")),
         }
 
         try!(write!(fmt, "]"));

--- a/test/test_delete.rs
+++ b/test/test_delete.rs
@@ -21,7 +21,7 @@ pub fn test_delete_with_no_body() {
     let res = res.unwrap();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }
 
 #[test]
@@ -48,5 +48,5 @@ pub fn test_delete_binary_with_slice() {
     let res = res.unwrap();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }

--- a/test/test_get.rs
+++ b/test/test_get.rs
@@ -20,9 +20,34 @@ pub fn test_simple_get() {
   srv.assert();
 
   assert!(res.get_code() == 200, "code is {}", res.get_code());
-  assert!(res.get_body() == "Hello".as_bytes());
+  assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
   assert!(res.get_headers().len() == 1);
   assert!(res.get_header("content-length") == ["5".to_string()]);
+}
+
+#[test]
+pub fn test_simple_get_with_empty_body() {
+  let srv = server!(
+    recv!(
+      b"GET / HTTP/1.1\r\n\
+        Host: localhost:{PORT}\r\n\
+        Accept: */*\r\n\r\n"), // Send the data
+    send!(
+      b"HTTP/1.1 200 OK\r\n\
+        Content-Length: 0\r\n\r\n\
+        \r\n")); // Sends
+
+  let res = handle()
+    .get(server::url("/"))
+    .exec().unwrap();
+
+  srv.assert();
+
+  println!("asdf:{:?}", res.get_body());
+  assert!(res.get_code() == 200, "code is {}", res.get_code());
+  assert!(res.get_body().clone().unwrap() == "".as_bytes());
+  assert!(res.get_headers().len() == 1);
+  assert!(res.get_header("content-length") == ["0".to_string()]);
 }
 
 #[test]
@@ -46,7 +71,7 @@ pub fn test_get_with_custom_headers() {
   srv.assert();
 
   assert!(res.get_code() == 200);
-  assert!(res.get_body() == "Hello".as_bytes());
+  assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
   assert!(res.get_headers().len() == 1);
   assert!(res.get_header("content-length") == ["5".to_string()]);
 }
@@ -110,5 +135,5 @@ pub fn follows_redirects() {
   srv2.assert();
 
   assert!(res.get_code() == 200);
-  assert_eq!(res.get_body(), b"response!");
+  assert_eq!(res.get_body().clone().unwrap(), b"response!");
 }

--- a/test/test_head.rs
+++ b/test/test_head.rs
@@ -20,7 +20,7 @@ pub fn test_simple_head() {
     let res = res.unwrap();
 
     assert!(res.get_code() == 200, "code is {}", res.get_code());
-    assert!(res.get_body() == []);
+    assert!(res.get_body().is_none());
     assert!(res.get_headers().len() == 1);
     assert!(res.get_header("content-length") == ["5".to_string()]);
 }

--- a/test/test_keep_alive.rs
+++ b/test/test_keep_alive.rs
@@ -25,10 +25,10 @@ pub fn test_get_requests() {
     srv.assert();
 
     assert!(res1.get_code() == 200);
-    assert!(res1.get_body() == "Hello".as_bytes());
+    assert!(res1.get_body().clone().unwrap() == "Hello".as_bytes());
 
     assert!(res2.get_code() == 200);
-    assert!(res2.get_body() == "World".as_bytes());
+    assert!(res2.get_body().clone().unwrap() == "World".as_bytes());
 }
 
 #[test]
@@ -59,10 +59,10 @@ pub fn test_post_get_requests() {
     srv.assert();
 
     assert!(res1.get_code() == 200);
-    assert!(res1.get_body() == "World".as_bytes(), "actual={}",
-            String::from_utf8_lossy(res1.get_body()));
+    assert!(res1.get_body().clone().unwrap() == "World".as_bytes(), "actual={}",
+            String::from_utf8_lossy(&res1.get_body().clone().unwrap()));
 
     assert!(res2.get_code() == 200);
-    assert!(res2.get_body() == "NEXT".as_bytes(), "actual={}",
-            String::from_utf8_lossy(res2.get_body()));
+    assert!(res2.get_body().clone().unwrap() == "NEXT".as_bytes(), "actual={}",
+            String::from_utf8_lossy(&res2.get_body().clone().unwrap()));
 }

--- a/test/test_keep_alive.rs
+++ b/test/test_keep_alive.rs
@@ -52,7 +52,7 @@ pub fn test_post_get_requests() {
                 NEXT\r\n\r\n")
     );
 
-    let mut handle = handle().timeout(1000);
+    let mut handle = handle().timeout(5000);
     let res1 = handle.post(server::url("/"), "Hello").exec().unwrap();
     let res2 = handle.get(server::url("/next")).exec().unwrap();
 

--- a/test/test_patch.rs
+++ b/test/test_patch.rs
@@ -23,7 +23,7 @@ pub fn test_patch_binary_with_slice() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }
 
 #[test]
@@ -49,5 +49,5 @@ pub fn test_patch_binary_with_content_type() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }

--- a/test/test_post.rs
+++ b/test/test_post.rs
@@ -23,7 +23,7 @@ pub fn test_post_binary_with_slice() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }
 
 #[test]
@@ -49,7 +49,7 @@ pub fn test_post_binary_with_string() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }
 
 #[test]
@@ -76,7 +76,7 @@ pub fn test_post_binary_with_reader() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }
 
 #[test]
@@ -103,5 +103,5 @@ pub fn test_post_binary_with_reader_and_content_length() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }

--- a/test/test_proxy.rs
+++ b/test/test_proxy.rs
@@ -26,5 +26,5 @@ pub fn test_proxy() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }

--- a/test/test_put.rs
+++ b/test/test_put.rs
@@ -23,7 +23,7 @@ pub fn test_put_binary_with_slice() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }
 
 #[test]
@@ -49,5 +49,5 @@ pub fn test_put_binary_with_content_type() {
     srv.assert();
 
     assert!(res.get_code() == 200);
-    assert!(res.get_body() == "Hello".as_bytes());
+    assert!(res.get_body().clone().unwrap() == "Hello".as_bytes());
 }


### PR DESCRIPTION
This is a first stab at https://github.com/carllerche/curl-rust/issues/5. I'm curious what methods can have optional body. Should we set it to None automatically if response is set to 0?