### PR TITLE
Increase timeout of request in test

### DIFF
--- a/test/test_keep_alive.rs
+++ b/test/test_keep_alive.rs
@@ -52,7 +52,7 @@ pub fn test_post_get_requests() {
                 NEXT\r\n\r\n")
     );
 
-    let mut handle = handle().timeout(1000);
+    let mut handle = handle().timeout(2000);
     let res1 = handle.post(server::url("/"), "Hello").exec().unwrap();
     let res2 = handle.get(server::url("/next")).exec().unwrap();
 


### PR DESCRIPTION
I noticed the **test_keep_alive::test_post_get_requests** test was periodically failing on travis. Increasing the timeout should should fix that.