### PR TITLE
Provide custom header callback in addition to progress

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate curl_sys as curl_ffi;
 #[cfg(all(unix, not(target_os = "macos")))]
 extern crate openssl_sys as openssl;
 
+pub use ffi::easy::HeaderCb;
 pub use ffi::easy::ProgressCb;
 pub use ffi::err::ErrCode;
 


### PR DESCRIPTION
This feature seems necessary for implementing rust-lang-nursery/rustup.rs#344, as `curl_easy_perform` is blocking.

I particularly don't like the name for the new builder method `header_cb` because it clashes with `headers`, but I couldn't immediately come up with a better name. Any suggestions on this?

BTW I'm relatively new to Rust (haven't used it for almost 1 year), so please kindly point out any mistake I might have made. Thanks!