### PR TITLE
docs: warn about ongoing API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # curl-rust
 
+**This project is in active development and	could (will probably) break API compatibility at any time**.
+
 libcurl bindings for Rust
 
 [![Build Status](https://travis-ci.org/alexcrichton/curl-rust.svg?branch=master)](https://travis-ci.org/alexcrichton/curl-rust)


### PR DESCRIPTION
Put an API instability warning in `README.md` on the `master` branch as well, since that's the docs that are being displayed to current crate users (and the message is relevant to the `master` branch as well).

Closes #107.