### PR TITLE
Attempt to use pkg-config even on Windows

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -34,17 +34,15 @@ fn main() {
     }
 
     // Next, fall back and try to use pkg-config if its available.
-    if !target.contains("windows") {
-        match pkg_config::find_library("libcurl") {
-            Ok(lib) => {
-                for path in lib.include_paths.iter() {
-                    println!("cargo:include={}", path.display());
-                }
-                return
+    match pkg_config::find_library("libcurl") {
+        Ok(lib) => {
+            for path in lib.include_paths.iter() {
+                println!("cargo:include={}", path.display());
             }
-            Err(e) => println!("Couldn't find libcurl from \
-                               pkgconfig ({:?}), compiling it from source...", e),
+            return
         }
+        Err(e) => println!("Couldn't find libcurl from \
+                           pkgconfig ({:?}), compiling it from source...", e),
     }
 
     if !Path::new("curl/.git").exists() {


### PR DESCRIPTION
The buildscript currently _never_ attempts `pkg-config` on Windows, even though MSYS2 provides `pkg-config` and a libcurl package. This need not be the case.

This is especially relevant because compiling `curl` from unpatched source under MSYS2 is tricky because MSYS2 does not provide the `strtok_r` function, leading to errors of this sort:

```
...\target\release\deps\libcurl_sys-d0dfe3f28a72a4ef.rlib(libcurl_la-cookie.o):cookie.c:
(.text$Curl_cookie_add+0x152): undefined reference to `strtok_r'
```
