### PR TITLE
Fix incorrect CURLOPT doc for `progress_function`

### DIFF
--- a/src/easy.rs
+++ b/src/easy.rs
@@ -646,7 +646,7 @@ impl Easy {
     /// called.
     ///
     /// By default this function calls an internal method and corresponds to
-    /// `CURLOPT_XFERINFOFUNCTION` and `CURLOPT_XFERINFODATA`.
+    /// `CURLOPT_PROGRESSFUNCTION` and `CURLOPT_PROGRESSDATA`.
     ///
     /// Note that the lifetime bound on this function is `'static`, but that
     /// is often too restrictive. To use stack data consider calling the


### PR DESCRIPTION
The method is implemented using CURLOPT_PROGRESS* callbacks, not CURLOPT_XFERINFO*