### PR TITLE
Use metadeps to specify pkg-config dependencies declaratively

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/carllerche/curl-rust"
 description = "Native bindings to the libcurl library"
 
 [build-dependencies]
-pkg-config = "0.3"
+metadeps = "1"
 gcc = "0.3.10"
 
 [lib]
@@ -26,3 +26,6 @@ openssl-sys = "0.9"
 
 [target."cfg(windows)".dependencies]
 winapi = "0.2"
+
+[package.metadata.pkg-config]
+libcurl = "7.51"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -1,4 +1,4 @@
-extern crate pkg_config;
+extern crate metadeps;
 extern crate gcc;
 
 use std::env;
@@ -35,13 +35,8 @@ fn main() {
 
     // Next, fall back and try to use pkg-config if its available.
     if !target.contains("windows") {
-        match pkg_config::find_library("libcurl") {
-            Ok(lib) => {
-                for path in lib.include_paths.iter() {
-                    println!("cargo:include={}", path.display());
-                }
-                return
-            }
+        match metadeps::probe() {
+            Ok(_) => return,
             Err(e) => println!("Couldn't find libcurl from \
                                pkgconfig ({:?}), compiling it from source...", e),
         }


### PR DESCRIPTION
This makes it easier for distribution packaging tools to generate
appropriate package dependencies.