### PR TITLE
curl-sys: fix call to `configure` in build script

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -143,9 +143,20 @@ fn main() {
 
     if target != host &&
        (!target.contains("windows") || !host.contains("windows")) {
-        cmd.arg(format!("--build={}", host));
-        cmd.arg(format!("--host={}", target));
-        cmd.arg(format!("--target={}", target));
+        // NOTE GNU terminology
+        // BUILD = machine where we are (cross) compiling curl
+        // HOST = machine where the compiled curl will be used
+        // TARGET = only relevant when compiling compilers
+        if target.contains("windows") {
+            // curl's configure can't parse `-windows-` triples when used
+            // as `--host`s. In those cases we use this combination of
+            // `host` and `target` that appears to do the right thing.
+            cmd.arg(format!("--host={}", host));
+            cmd.arg(format!("--target={}", target));
+        } else {
+            cmd.arg(format!("--build={}", host));
+            cmd.arg(format!("--host={}", target));
+        }
     }
 
     if let Some(root) = nghttp2_root {

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -143,7 +143,8 @@ fn main() {
 
     if target != host &&
        (!target.contains("windows") || !host.contains("windows")) {
-        cmd.arg(format!("--host={}", host));
+        cmd.arg(format!("--build={}", host));
+        cmd.arg(format!("--host={}", target));
         cmd.arg(format!("--target={}", target));
     }
 


### PR DESCRIPTION
the old form caused `configure` to probe the environment using some
tests that looked like this:

```
$ $TARGET-gcc conftest.c
$ ./conftest
```

which always failed because `conftest` could have been compiled for e.g.
MIPS but was being called from a x86_64 system.

With the new form, `configure` never call `conftest` in its tests.

r? @alexcrichton 