### PR TITLE
Enable using precompiled mingw version.

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -34,7 +34,7 @@ fn main() {
     }
 
     // Next, fall back and try to use pkg-config if its available.
-    if !target.contains("windows") {
+    if !target.contains("msvc") {
         match pkg_config::find_library("libcurl") {
             Ok(lib) => {
                 for path in lib.include_paths.iter() {


### PR DESCRIPTION
Hi, I tried building this repo yesterday and found that it failed to build. 

Yes i know that it's because i'm building under Windows and yes i've building it from cmd.exe, not mingw64 shell. 

However after investigation i found that there's a line precluding using the mingw libcurl prebuilt version.
I edited it and it successfully use the information retrieved from pkg-config, which builds fine.

Is there a special reason for not allowing using the mingw version?