### PR TITLE
Add Multi::wait function

### DIFF
--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -9,7 +9,7 @@ extern crate openssl_sys;
 #[cfg(windows)]
 extern crate winapi;
 
-use libc::{c_int, c_char, c_uint, c_long, c_double, c_void, size_t, time_t};
+use libc::{c_int, c_char, c_uint, c_short, c_long, c_double, c_void, size_t, time_t};
 use libc::c_ulong;
 
 #[cfg(unix)]
@@ -890,16 +890,16 @@ pub struct CURLMsg {
     pub data: *mut c_void,
 }
 
-// pub const CURL_WAIT_POLLIN: c_short = 0x1;
-// pub const CURL_WAIT_POLLPRI: c_short = 0x2;
-// pub const CURL_WAIT_POLLOUT: c_short = 0x4;
+pub const CURL_WAIT_POLLIN: c_short = 0x1;
+pub const CURL_WAIT_POLLPRI: c_short = 0x2;
+pub const CURL_WAIT_POLLOUT: c_short = 0x4;
 
-// #[repr(C)]
-// pub struct curl_waitfd {
-//     pub fd: curl_socket_t,
-//     pub events: c_short,
-//     pub revents: c_short,
-// }
+#[repr(C)]
+pub struct curl_waitfd {
+    pub fd: curl_socket_t,
+    pub events: c_short,
+    pub revents: c_short,
+}
 
 pub const CURL_POLL_NONE: c_int = 0;
 pub const CURL_POLL_IN: c_int = 1;
@@ -1010,11 +1010,11 @@ extern {
                             write_fd_set: *mut fd_set,
                             exc_fd_set: *mut fd_set,
                             max_fd: *mut c_int) -> CURLMcode;
-    // pub fn curl_multi_wait(multi_handle: *mut CURLM,
-    //                        extra_fds: *mut curl_waitfd,
-    //                        extra_nfds: c_uint,
-    //                        timeout_ms: c_int,
-    //                        ret: *mut c_int) -> CURLMcode;
+    pub fn curl_multi_wait(multi_handle: *mut CURLM,
+                           extra_fds: *mut curl_waitfd,
+                           extra_nfds: c_uint,
+                           timeout_ms: c_int,
+                           ret: *mut c_int) -> CURLMcode;
     pub fn curl_multi_perform(multi_handle: *mut CURLM,
                               running_handles: *mut c_int) -> CURLMcode;
     pub fn curl_multi_cleanup(multi_handle: *mut CURLM) -> CURLMcode;

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -36,7 +36,7 @@ Accept: */*\r\n\
     t!(e.url(&s.url("/")));
     let _e = t!(m.add(e));
     while t!(m.perform()) > 0 {
-        t!(m.wait(1000));
+        t!(m.wait(Duration::from_secs(1)));
     }
 }
 
@@ -68,7 +68,7 @@ Accept: */*\r\n\
     let _e2 = t!(m.add(e2));
 
     while t!(m.perform()) > 0 {
-        t!(m.wait(1000));
+        t!(m.wait(Duration::from_secs(1)));
     }
 
     let mut done = 0;

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -222,7 +222,10 @@ HTTP/1.1 200 OK\r\n\
     assert_eq!(t!(e.response_code()), 200);
 }
 
-#[cfg(unix)]
+// Tests passing raw file descriptors to Multi::wait. The test is limited to Linux only as the
+// semantics of the underlying poll(2) system call used by curl apparently differ on other
+// platforms, making the test fail.
+#[cfg(target_os = "linux")]
 #[test]
 fn waitfds() {
     use std::fs::File;

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -36,7 +36,7 @@ Accept: */*\r\n\
     t!(e.url(&s.url("/")));
     let _e = t!(m.add(e));
     while t!(m.perform()) > 0 {
-        // ...
+        t!(m.wait(1000));
     }
 }
 
@@ -68,7 +68,7 @@ Accept: */*\r\n\
     let _e2 = t!(m.add(e2));
 
     while t!(m.perform()) > 0 {
-        // ...
+        t!(m.wait(1000));
     }
 
     let mut done = 0;


### PR DESCRIPTION
[curl_multi_wait](https://curl.haxx.se/libcurl/c/curl_multi_wait.html) is the recommended function for performing requests with the multi API.

I'm not sure about the `i32` timeout parameter. While it matches the curl API, a `Duration` would probably be nicer. These have a larger range though, so we'd either have to return an error or clamp to the largest `i32` for huge timeout values.

`curl_multi_wait` was introduced five years ago in curl 7.28.0 which is probably the minimum required curl version then. 