### PR TITLE
Explicitly disable PSL support for curl-sys

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -168,6 +168,7 @@ fn main() {
     cmd.arg("--without-librtmp");
     cmd.arg("--without-libidn");
     cmd.arg("--without-libssh2");
+    cmd.arg("--without-libpsl");
     cmd.arg("--disable-ldap");
     cmd.arg("--disable-ldaps");
     cmd.arg("--disable-ftp");


### PR DESCRIPTION
If the PSL (Public Suffix List) library is installed on the host, curl's `configure` script will enable it, but the curl-sys `build.rs` doesn't include it in the library list, so subsequent linking with libcurl-sys will fail. Since curl-sys doesn't need PSL support, it's best to disable it explicitly.