### PR TITLE
optionally use static or dynamic build of libcurl from vcpkg

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,10 +22,17 @@ environment:
     ARCH: amd64
     VS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
 
+  # Ensure getting libcurl from vcpkg works
+  - TARGET: x86_64-pc-windows-msvc
+    RUSTFLAGS: -Ctarget-feature=+crt-static
+    VCPKG_DEFAULT_TRIPLET: x64-windows-static
+
 install:
   # Install rust, x86_64-pc-windows-msvc host
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc
+  # use nightly if required until -Ctarget-feature=+crt-static is stable (expected in rust 1.19)
+  - if not defined RUSTFLAGS rustup-init.exe -y --default-host x86_64-pc-windows-msvc
+  - if defined RUSTFLAGS rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
 
   # Install the target we're compiling for
@@ -47,6 +54,12 @@ install:
   - rustc -vV
   - cargo -vV
   - set CARGO_TARGET_DIR=%CD%\target
+
+  # install vcpkg if required
+  - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
+  - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install curl
 
 build: false
 

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -19,6 +19,9 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 pkg-config = "0.3"
 gcc = "0.3.10"
 
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2"
+
 [lib]
 name = "curl_sys"
 path = "lib.rs"


### PR DESCRIPTION
@alexcrichton, a while ago I asked you for a suggestion for a library that I should use to test the vcpkg build helper on, and you suggested curl-sys. 

This PR adds support for getting libcurl from a vcpkg tree (for MSVC ABI builds). It requires vcpkg enabled versions of all of the sys crates that it depends on, which I have also made PRs for. (zlib, libssh2, openssl.) The version of libssh2 in the vcpkg ports tree depends on openssl, whereas the present version uses WinCNG, so the new search requires feature `use-vcpkg`to avoid giving everyone a dependency on openssl.

I have no specific use for vcpkgified versions of curl/ssh2/zlib - these were just used as an example to prove out the mechanism. It doesn't really add much since curl and libssh2 already seamlessly build themselves.

The motivating reason for working on the vcpkg build helper at all is to make it possible to much more simply `cargo install` some tools on windows machines. I have a branch of diesel that can cargo install a static version of itself that I am hoping to merge back which would require the openssl-sys changes.

I think it really only needs to switch back to crates.io versions of the deps to be done. Let me know if you think it is useful and I can get that done.