### PR TITLE
Open all sockets with CLOEXEC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 [dependencies]
 libc = "0.2"
 curl-sys = { path = "curl-sys", version = "0.3.10" }
+socket2 = "0.2"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -162,29 +162,12 @@ pub type curl_read_callback = extern fn(*mut c_char,
                                         size_t,
                                         *mut c_void) -> size_t;
 
-// pub type curlsocktype = __enum_ty;
-// pub const CURLSOCKTYPE_IPCXN: curlsocktype = 0;
-// pub const CURLSOCKTYPE_ACCEPT: curlsocktype = 1;
 // pub const CURL_SOCKOPT_OK: c_int = 0;
 // pub const CURL_SOCKOPT_ERROR: c_int = 1;
 // pub const CURL_SOCKOPT_ALREADY_CONNECTED: c_int = 2;
 // pub type curl_sockopt_callback = extern fn(*mut c_void,
 //                                            curl_socket_t,
 //                                            curlsocktype) -> c_int;
-
-// TODO: sort out libc::sockaddr on windows
-// #[repr(C)]
-// pub struct curl_sockaddr {
-//     pub family: c_int,
-//     pub socktype: c_int,
-//     pub protocol: c_int,
-//     pub addrlen: c_uint,
-//     pub addr: libc::sockaddr,
-// }
-//
-// pub type curl_opensocket_callback = extern fn(*mut c_void,
-//                                               curlsocktype,
-//                                               *mut curl_sockaddr) -> curl_socket_t;
 
 pub type curlioerr = __enum_ty;
 pub const CURLIOE_OK: curlioerr = 0;
@@ -941,6 +924,26 @@ pub const CURLMOPT_TIMERDATA: CURLMoption = CURLOPTTYPE_OBJECTPOINT + 5;
 // pub const CURLMOPT_MAX_TOTAL_CONNECTIONS: CURLMoption = CURLOPTTYPE_LONG + 13;
 
 pub const CURL_ERROR_SIZE: usize = 256;
+
+pub type curl_opensocket_callback = extern fn(*mut c_void,
+                                              curlsocktype,
+                                              *mut curl_sockaddr) -> curl_socket_t;
+pub type curlsocktype = __enum_ty;
+pub const CURLSOCKTYPE_IPCXN: curlsocktype = 0;
+pub const CURLSOCKTYPE_ACCEPT: curlsocktype = 1;
+pub const CURLSOCKTYPE_LAST: curlsocktype = 2;
+
+#[repr(C)]
+pub struct curl_sockaddr {
+    pub family: c_int,
+    pub socktype: c_int,
+    pub protocol: c_int,
+    pub addrlen: c_uint,
+    #[cfg(unix)]
+    pub addr: libc::sockaddr,
+    #[cfg(windows)]
+    pub addr: winapi::SOCKADDR,
+}
 
 extern {
     pub fn curl_formadd(httppost: *mut *mut curl_httppost,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 
 extern crate curl_sys;
 extern crate libc;
+extern crate socket2;
 
 #[cfg(all(unix, not(target_os = "macos")))]
 extern crate openssl_sys;


### PR DESCRIPTION
Leverage the open socket callback in libcurl to open all sockets with CLOEXEC,
leveraging `socket2` to provide the necessary runtime support.