### PR TITLE
added support for CURLOPT_RESOLVE

### DIFF
--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -882,6 +882,11 @@ impl Easy {
         self.inner.ip_resolve(resolve)
     }
 
+    /// Same as [`Easy2::resolve`](struct.Easy2.html#method.resolve)
+    pub fn resolve(&mut self, list: List) -> Result<(), Error> {
+        self.inner.resolve(list)
+    }
+
     /// Same as [`Easy2::connect_only`](struct.Easy2.html#method.connect_only)
     pub fn connect_only(&mut self, enable: bool) -> Result<(), Error> {
         self.inner.connect_only(enable)

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -1713,6 +1713,30 @@ impl<H> Easy2<H> {
         self.setopt_long(curl_sys::CURLOPT_IPRESOLVE, resolve as c_long)
     }
 
+    /// Specify custom host name to IP address resolves.
+    ///
+    /// Allows specifying hostname to IP mappins to use before trying the
+    /// system resolver.
+    ///
+    /// # Examples
+    /// ...
+    /// use curl::easy::{Easy, List};
+    ///
+    /// let mut list = List::new();
+    /// list.append("www.rust-lang.org:443:192.241.171.49").unwrap();
+    ///
+    /// let mut handle = Easy::new();
+    /// handle.url("https://www-rust-lang.org/".unwrap();
+    /// handle.resolve(list).unwrap();
+    /// handle.perform().unwrap();
+    /// ...
+    pub fn resolve(&mut self, list: List) -> Result<(), Error> {
+        let ptr = list::raw(&list);
+        self.inner.header_list = Some(list);
+        self.setopt_ptr(curl_sys::CURLOPT_RESOLVE, ptr as *const _)
+    }
+
+
     /// Configure whether to stop when connected to target server
     ///
     /// When enabled it tells the library to perform all the required proxy


### PR DESCRIPTION

I use this option to connect to a specific IP address of a multi-homed device but still be able to verify the certificate presented.