### PR TITLE
Allow OSX users to link with customly built libcurl

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -25,8 +25,8 @@ fn main() {
     let windows = target.contains("windows");
 
     // OSX ships libcurl by default, so we just use that version
-    // unconditionally.
-    if target.contains("apple") {
+    // unless the user objects.
+    if target.contains("apple") && env::var("RUST_CURL_DONT_USE_OSX_SHIPPED").is_err() {
         return println!("cargo:rustc-flags=-l curl");
     }
 


### PR DESCRIPTION
This commit changes curl-sys's build script behavior for OSX targets
when environment variable RUST_CURL_DONT_USE_OSX_SHIPPED is set: it will
fall back to use pkg-config for library searching, which allows the
user to specify a custom libcurl.

This is useful in situations where the default system libcurl doesn't
provide enough functionalities (e.g. the user wants to use OpenSSL
rather than SecureTransport as the TLS backend).