### PR TITLE
use openssl-probe to look for root certificates on windows also

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ openssl-probe = "0.1"
 
 [target."cfg(windows)".dependencies]
 winapi = "0.2"
+openssl-probe = "0.1"
 
 [dev-dependencies]
 mio = "0.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
     RUSTFLAGS: -Ctarget-feature=+crt-static
     VCPKG_DEFAULT_TRIPLET: x64-windows-static
+    SSL_CERT_FILE: "C:\\OpenSSL\\cacert.pem"
 
 install:
   # Install rust, x86_64-pc-windows-msvc host
@@ -61,6 +62,8 @@ install:
   - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
   - if defined VCPKG_DEFAULT_TRIPLET echo yes > %VCPKG_ROOT%\Downloads\AlwaysAllowDownloads  
   - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install curl
+  - if defined VCPKG_DEFAULT_TRIPLET mkdir C:\OpenSSL
+  - if defined VCPKG_DEFAULT_TRIPLET appveyor DownloadFile https://curl.haxx.se/ca/cacert.pem -FileName C:\OpenSSL\cacert.pem
 
 build: false
 

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -685,7 +685,7 @@ impl<H: Handler> Easy2<H> {
             .expect("failed to set open socket callback");
     }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(any(all(unix, not(target_os = "macos")), windows))]
     fn ssl_configure(&mut self) {
         let probe = ::openssl_probe::probe();
         if let Some(ref path) = probe.cert_file {
@@ -696,7 +696,7 @@ impl<H: Handler> Easy2<H> {
         }
     }
 
-    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    #[cfg(not(any(all(unix, not(target_os = "macos")), windows)))]
     fn ssl_configure(&mut self) {}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ extern crate socket2;
 
 #[cfg(all(unix, not(target_os = "macos")))]
 extern crate openssl_sys;
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(any(all(unix, not(target_os = "macos")), windows))]
 extern crate openssl_probe;
 #[cfg(windows)]
 extern crate winapi;


### PR DESCRIPTION
This makes Easy2 use openssl-probe on Windows also. (Vcpkg by default builds a libcurl that uses OpenSSL.)

I verified that the libcurl built into curl-sys still works if the SSL_CERT_FILE environment variable is set.

This fixes this test failure on appveyor: https://ci.appveyor.com/project/alexcrichton/curl-rust/build/job/3v6g79vc3htcrm5t