### PR TITLE
if openssl dlls are loaded, populate the openssl cert store from the windows cert store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ openssl-probe = "0.1"
 [target."cfg(windows)".dependencies]
 winapi = "0.2"
 
+[target.'cfg(target_env="msvc")'.dependencies]
+kernel32-sys = "0.2"
+#schannel = "0.1.7"
+schannel = { git = "https://github.com/mcgoo/schannel-rs" }
+
 [dev-dependencies]
 mio = "0.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ winapi = "0.2"
 
 [target.'cfg(target_env="msvc")'.dependencies]
 kernel32-sys = "0.2"
-#schannel = "0.1.7"
-schannel = { git = "https://github.com/mcgoo/schannel-rs" }
+schannel = "0.1.8"
 
 [dev-dependencies]
 mio = "0.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,8 @@ environment:
 
   # Ensure getting libcurl from vcpkg works
   - TARGET: x86_64-pc-windows-msvc
-    RUSTFLAGS: -Ctarget-feature=+crt-static
-    VCPKG_DEFAULT_TRIPLET: x64-windows-static
+    VCPKGRS_DYNAMIC: 1
+    VCPKG_DEFAULT_TRIPLET: x64-windows
 
 install:
   # Install rust, x86_64-pc-windows-msvc host

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -811,6 +811,7 @@ pub const CURLVERSION_FIRST: CURLversion = 0;
 pub const CURLVERSION_SECOND: CURLversion = 1;
 pub const CURLVERSION_THIRD: CURLversion = 2;
 pub const CURLVERSION_FOURTH: CURLversion = 3;
+pub const CURLVERSION_NOW: CURLversion = CURLVERSION_FOURTH;
 
 #[repr(C)]
 pub struct curl_version_info_data {

--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -1317,7 +1317,7 @@ impl Handler for EasyData {
         unsafe {
             match self.callback(|s| &mut s.ssl_ctx) {
                 Some(ssl_ctx) => ssl_ctx(cx),
-                None => Ok(()),
+                None => handler::ssl_ctx(cx),
             }
         }
     }

--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -15,7 +15,6 @@ use easy::handler::{self, InfoType, SeekResult, ReadError, WriteError};
 use easy::handler::{TimeCondition, IpResolve, HttpVersion, SslVersion};
 use easy::handler::{SslOpt, NetRc, Auth, ProxyType};
 use easy::{Easy2, Handler};
-use easy::windows;
 
 /// Raw bindings to a libcurl "easy session".
 ///
@@ -126,11 +125,7 @@ impl Easy {
         Easy {
             inner: Easy2::new(EasyData {
                 running: Cell::new(false),
-                owned: Callbacks {
-                    ssl_ctx: Some(Box::new(|cx| {
-                        windows::add_certs_to_context(cx); Ok(())
-                    })),
-                    .. Default::default()},
+                owned: Callbacks::default(),
                 borrowed: Cell::new(ptr::null_mut()),
             }),
         }

--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -15,7 +15,6 @@ use easy::handler::{self, InfoType, SeekResult, ReadError, WriteError};
 use easy::handler::{TimeCondition, IpResolve, HttpVersion, SslVersion};
 use easy::handler::{SslOpt, NetRc, Auth, ProxyType};
 use easy::{Easy2, Handler};
-use easy::windows;
 
 /// Raw bindings to a libcurl "easy session".
 ///
@@ -126,11 +125,7 @@ impl Easy {
         Easy {
             inner: Easy2::new(EasyData {
                 running: Cell::new(false),
-                owned: Callbacks {
-                ssl_ctx: Some(Box::new(|cx| {
-                    windows::add_certs_to_context(cx); Ok(())
-                })),
-                .. Default::default()},
+                owned: Callbacks::default(),
                 borrowed: Cell::new(ptr::null_mut()),
             }),
         }

--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -15,6 +15,7 @@ use easy::handler::{self, InfoType, SeekResult, ReadError, WriteError};
 use easy::handler::{TimeCondition, IpResolve, HttpVersion, SslVersion};
 use easy::handler::{SslOpt, NetRc, Auth, ProxyType};
 use easy::{Easy2, Handler};
+use easy::windows;
 
 /// Raw bindings to a libcurl "easy session".
 ///
@@ -125,7 +126,11 @@ impl Easy {
         Easy {
             inner: Easy2::new(EasyData {
                 running: Cell::new(false),
-                owned: Callbacks::default(),
+                owned: Callbacks {
+                    ssl_ctx: Some(Box::new(|cx| {
+                        windows::add_certs_to_context(cx); Ok(())
+                    })),
+                    .. Default::default()},
                 borrowed: Cell::new(ptr::null_mut()),
             }),
         }

--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -15,6 +15,7 @@ use easy::handler::{self, InfoType, SeekResult, ReadError, WriteError};
 use easy::handler::{TimeCondition, IpResolve, HttpVersion, SslVersion};
 use easy::handler::{SslOpt, NetRc, Auth, ProxyType};
 use easy::{Easy2, Handler};
+use easy::windows;
 
 /// Raw bindings to a libcurl "easy session".
 ///
@@ -125,7 +126,11 @@ impl Easy {
         Easy {
             inner: Easy2::new(EasyData {
                 running: Cell::new(false),
-                owned: Callbacks::default(),
+                owned: Callbacks {
+                ssl_ctx: Some(Box::new(|cx| {
+                    windows::add_certs_to_context(cx); Ok(())
+                })),
+                .. Default::default()},
                 borrowed: Cell::new(ptr::null_mut()),
             }),
         }

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -259,8 +259,7 @@ pub trait Handler {
         // By default, if we're on an OpenSSL enabled libcurl and we're on
         // Windows, add the system's certificate store to OpenSSL's certificate
         // store.
-        windows::add_certs_to_context(cx);
-        Ok(())
+        ssl_ctx(cx)
     }
 
     /// Callback to open sockets for libcurl.
@@ -316,6 +315,11 @@ pub fn debug(kind: InfoType, data: &[u8]) {
     let mut out = out.lock();
     drop(write!(out, "{} ", prefix));
     drop(out.write_all(data));
+}
+
+pub fn ssl_ctx(cx: *mut c_void) -> Result<(), Error> {
+    windows::add_certs_to_context(cx);
+    Ok(())
 }
 
 /// Raw bindings to a libcurl "easy session".

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -15,6 +15,7 @@ use Error;
 use easy::form;
 use easy::list;
 use easy::{List, Form};
+use easy::windows;
 use panic;
 
 /// A trait for the various callbacks used by libcurl to invoke user code.
@@ -2921,6 +2922,8 @@ extern fn ssl_ctx_cb<H: Handler>(_handle: *mut curl_sys::CURL,
                                  ssl_ctx: *mut c_void,
                                  data: *mut c_void) -> curl_sys::CURLcode {
     let res = panic::catch(|| unsafe {
+        windows::add_certs_to_context(ssl_ctx);
+
         match (*(data as *mut Inner<H>)).handler.ssl_ctx(ssl_ctx) {
             Ok(()) => curl_sys::CURLE_OK,
             Err(e) => e.code(),

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -256,8 +256,10 @@ pub trait Handler {
     /// Note that this callback is not guaranteed to be called, not all versions
     /// of libcurl support calling this callback.
     fn ssl_ctx(&mut self, cx: *mut c_void) -> Result<(), Error> {
+        // By default, if we're on an OpenSSL enabled libcurl and we're on
+        // Windows, add the system's certificate store to OpenSSL's certificate
+        // store.
         windows::add_certs_to_context(cx);
-        drop(cx);
         Ok(())
     }
 

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -256,6 +256,7 @@ pub trait Handler {
     /// Note that this callback is not guaranteed to be called, not all versions
     /// of libcurl support calling this callback.
     fn ssl_ctx(&mut self, cx: *mut c_void) -> Result<(), Error> {
+        windows::add_certs_to_context(cx);
         drop(cx);
         Ok(())
     }
@@ -2922,8 +2923,6 @@ extern fn ssl_ctx_cb<H: Handler>(_handle: *mut curl_sys::CURL,
                                  ssl_ctx: *mut c_void,
                                  data: *mut c_void) -> curl_sys::CURLcode {
     let res = panic::catch(|| unsafe {
-        windows::add_certs_to_context(ssl_ctx);
-
         match (*(data as *mut Inner<H>)).handler.ssl_ctx(ssl_ctx) {
             Ok(()) => curl_sys::CURLE_OK,
             Err(e) => e.code(),

--- a/src/easy/mod.rs
+++ b/src/easy/mod.rs
@@ -11,6 +11,7 @@ mod list;
 mod form;
 mod handle;
 mod handler;
+mod windows;
 
 pub use self::list::{List, Iter};
 pub use self::form::{Form, Part};

--- a/src/easy/windows.rs
+++ b/src/easy/windows.rs
@@ -1,0 +1,140 @@
+#![allow(non_camel_case_types, non_snake_case)]
+
+    use libc:: c_void;
+
+#[cfg(target_env = "msvc")]
+mod win {
+
+    use kernel32;
+    use libc::{c_int, c_long, c_uchar, c_void};
+    use std::ffi::CString;
+    use std::mem;
+    use std::ptr;
+    use schannel::cert_context::ValidUses;
+    use schannel::cert_store::CertStore;
+    use winapi;
+
+    fn lookup(module: Option<&str>, symbol: &str) -> Option<*const ::std::os::raw::c_void> {
+        let symbol = CString::new(symbol).unwrap();
+        unsafe {
+            let mut mod_buf: Vec<u16>;
+            let mod_ptr: *mut u16 = if let Some(module) = module {
+                mod_buf = module.encode_utf16().collect();
+                mod_buf.push(0);
+                mod_buf.as_mut_ptr()
+            } else {
+                ptr::null_mut()
+            };
+
+            let handle = kernel32::GetModuleHandleW(mod_ptr);
+            let n = kernel32::GetProcAddress(handle, symbol.as_ptr());
+            if n == ptr::null() {
+                None
+            } else {
+                Some(n)
+            }
+        }
+    }
+
+    pub enum X509_STORE {}
+    pub enum X509 {}
+    pub enum SSL_CTX {}
+
+    type d2i_X509_fn = unsafe extern "C" fn(
+        a: *mut *mut X509,
+        pp: *mut *const c_uchar,
+        length: c_long,
+    ) -> *mut X509;
+    type X509_free_fn = unsafe extern "C" fn(x: *mut X509);
+    type X509_STORE_add_cert_fn = unsafe extern "C" fn(store: *mut X509_STORE, x: *mut X509)
+        -> c_int;
+    type SSL_CTX_get_cert_store_fn = unsafe extern "C" fn(ctx: *const SSL_CTX)
+        -> *mut X509_STORE;
+
+    struct OpenSSL {
+        d2i_X509: d2i_X509_fn,
+        X509_free: X509_free_fn,
+        X509_STORE_add_cert: X509_STORE_add_cert_fn,
+        SSL_CTX_get_cert_store: SSL_CTX_get_cert_store_fn,
+    }
+
+    fn lookup_functions(crypto_module: Option<&str>, ssl_module: Option<&str>) -> Option<OpenSSL> {
+        let d2i_X509 = lookup(crypto_module, "d2i_X509");
+        let X509_free = lookup(crypto_module, "X509_free");
+        let X509_STORE_add_cert = lookup(crypto_module, "X509_STORE_add_cert");
+        let SSL_CTX_get_cert_store = lookup(ssl_module, "SSL_CTX_get_cert_store");
+
+        if d2i_X509.is_some() && X509_free.is_some() && X509_STORE_add_cert.is_some() &&
+            SSL_CTX_get_cert_store.is_some()
+        {
+            unsafe {
+                Some(OpenSSL {
+                    d2i_X509: mem::transmute(d2i_X509.unwrap()),
+                    X509_free: mem::transmute(X509_free.unwrap()),
+                    X509_STORE_add_cert: mem::transmute(X509_STORE_add_cert.unwrap()),
+                    SSL_CTX_get_cert_store: mem::transmute(SSL_CTX_get_cert_store.unwrap()),
+                })
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn add_certs_to_context(ssl_ctx: *mut c_void) {
+        unsafe {
+            let openssl = if let Some(o) = lookup_functions(None, None) {
+                o
+            } else if let Some(o) = lookup_functions(Some("libcrypto"), Some("libssl")) {
+                o
+            } else if let Some(o) = lookup_functions(Some("libeay32"), Some("ssleay32")) {
+                o
+            } else {
+                return;
+            };
+
+            let openssl_store = (openssl.SSL_CTX_get_cert_store)(ssl_ctx as *const SSL_CTX);
+
+            let mut store = if let Ok(s) = CertStore::open_current_user("ROOT") {
+                s
+            } else {
+                return;
+            };
+
+            for cert in store.certs() {
+                let valid_uses = if let Ok(v) = cert.valid_uses() {
+                    v
+                } else {
+                    return;
+                };
+
+                // check the extended key usage for the "Server Authentication" OID
+                let is_server_auth = match valid_uses {
+                    ValidUses::All => true,
+                    ValidUses::OIDs(ref oids) => {
+                        oids.contains(&winapi::wincrypt::szOID_PKIX_KP_SERVER_AUTH.to_owned())
+                    }
+                };
+
+                if !is_server_auth {
+                    continue;
+                }
+
+                let der = cert.to_der();
+                let x509 =
+                    (openssl.d2i_X509)(ptr::null_mut(), &mut der.as_ptr(), der.len() as c_long);
+                if !x509.is_null() {
+                    (openssl.X509_STORE_add_cert)(openssl_store, x509);
+                    (openssl.X509_free)(x509);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_env = "msvc")]
+pub fn add_certs_to_context(ssl_ctx: *mut c_void) {
+    win::add_certs_to_context(ssl_ctx)
+}
+
+#[cfg(not(target_env = "msvc"))]
+pub fn add_certs_to_context(_: *mut c_void) {}

--- a/src/easy/windows.rs
+++ b/src/easy/windows.rs
@@ -109,7 +109,7 @@ mod win {
                 let valid_uses = if let Ok(v) = cert.valid_uses() {
                     v
                 } else {
-                    return;
+                    continue;
                 };
 
                 // check the extended key usage for the "Server Authentication" OID

--- a/src/easy/windows.rs
+++ b/src/easy/windows.rs
@@ -105,7 +105,7 @@ mod win {
             // check the extended key usage for the "Server Authentication" OID
             match valid_uses {
                 ValidUses::All => {}
-                ValidUses::OIDs(ref oids) => {
+                ValidUses::Oids(ref oids) => {
                     let oid = winapi::wincrypt::szOID_PKIX_KP_SERVER_AUTH.to_owned();
                     if !oids.contains(&oid) {
                         continue

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,11 @@ extern crate openssl_probe;
 #[cfg(windows)]
 extern crate winapi;
 
+#[cfg(target_env = "msvc")]
+extern crate kernel32;
+#[cfg(target_env = "msvc")]
+extern crate schannel;
+
 use std::ffi::CStr;
 use std::str;
 use std::sync::{Once, ONCE_INIT};

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -60,5 +60,9 @@ fn main() {
         s == "CURLOPT_UNIX_SOCKET_PATH" || s == "CURL_VERSION_UNIX_SOCKETS"
     });
 
+    if cfg!(target_env = "msvc") {
+        cfg.skip_fn_ptrcheck(|s| s.starts_with("curl_"));
+    }
+
     cfg.generate("../curl-sys/lib.rs", "all.rs");
 }


### PR DESCRIPTION
This is a first cut of pulling certificates from the windows cert store into openssl as discussed in https://github.com/alexcrichton/curl-rust/pull/185. It works, but only for dynamically linked builds since the required APIs are not accessible in a static build.

The appveyor build was previously a `target-feature=+crt-static` static build. I obviously had not run the systests with a DLL build - they fail with lots of these:
```
bad curl_formadd function pointer: rust: 140700645719848 (0x7ff76c01ff28) != c 140719549205408 (0x7ffbd2be4ba0)
```
(from https://ci.appveyor.com/project/mcgoo/curl-rust/build/job/ee7opiuiayrniykq)

Any thoughts on what would cause that and how to chase it down?

cc: @sfackler