### PR TITLE
Replace --without-libidn with --without-libidn2

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -173,7 +173,7 @@ fn main() {
     }
 
     cmd.arg("--without-librtmp");
-    cmd.arg("--without-libidn");
+    cmd.arg("--without-libidn2");
     cmd.arg("--without-libssh2");
     cmd.arg("--without-libpsl");
     cmd.arg("--disable-ldap");


### PR DESCRIPTION
Curl uses libidn2, libidn is gone. The `--without-libidn` has no effect.

I found this while building statically-linked binaries of cargo for
DragonFly (which fails without this option).