### PR TITLE
Accessors for handler even after attached to multi

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -645,6 +645,16 @@ impl fmt::Debug for EasyHandle {
 }
 
 impl<H> Easy2Handle<H> {
+    /// Acquires a reference to the underlying handler for events.
+    pub fn get_ref(&self) -> &H {
+        self.easy.get_ref()
+    }
+
+    /// Acquires a reference to the underlying handler for events.
+    pub fn get_mut(&mut self) -> &mut H {
+        self.easy.get_mut()
+    }
+
     /// Same as `EasyHandle::set_token`
     pub fn set_token(&mut self, token: usize) -> Result<(), Error> {
         unsafe {


### PR DESCRIPTION
Add accessors to the inner handler type that mirror the ones provided by `Easy2`. Useful if a callback handler has internal state useful to read while a request is active.

For context, I am currently writing code that encapsulates curl which handles buffering in a streaming/incremental way. Right now to access the buffer I have to put it in an `Rc<RefCell<T>>` so that both the callback struct and the rest of the code can access it.

I'm not 100% knowledgeable about libcurl's thread and lifetime requirements, but from what I understand accessing the callback data is OK (just not the `Easy2` itself).