### PR TITLE
Add support for CURLMOPT_PIPELINING

### DIFF
--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -926,6 +926,11 @@ pub const CURLMOPT_TIMERDATA: CURLMoption = CURLOPTTYPE_OBJECTPOINT + 5;
 // pub const CURLMOPT_PIPELINING_SERVER_BL: CURLMoption = CURLOPTTYPE_OBJECTPOINT + 12;
 // pub const CURLMOPT_MAX_TOTAL_CONNECTIONS: CURLMoption = CURLOPTTYPE_LONG + 13;
 
+// These enums are for use with the CURLMOPT_PIPELINING option.
+pub const CURLPIPE_NOTHING: c_long = 0;
+pub const CURLPIPE_HTTP1: c_long = 1;
+pub const CURLPIPE_MULTIPLEX: c_long = 2;
+
 pub const CURL_ERROR_SIZE: usize = 256;
 
 pub type curl_opensocket_callback = extern fn(*mut c_void,

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -254,6 +254,30 @@ impl Multi {
         }
     }
 
+    /// Enable or disable HTTP pipelining and multiplexing.
+    ///
+    /// When http_1 is true, enable HTTP/1.1 pipelining, which means that if
+    /// you add a second request that can use an already existing connection,
+    /// the second request will be "piped" on the same connection rather than
+    /// being executed in parallel.
+    ///
+    /// When multiplex is true, enable HTTP/2 multiplexing, which means that
+    /// follow-up requests can re-use an existing connection and send the new
+    /// request multiplexed over that at the same time as other transfers are
+    /// already using that single connection.
+    pub fn pipelining(&mut self, http_1: bool, multiplex: bool) -> Result<(), MultiError> {
+        let bitmask = if http_1 { curl_sys::CURLPIPE_HTTP1 } else { 0 } | if multiplex { curl_sys::CURLPIPE_MULTIPLEX } else { 0 };
+        self.setopt_long(curl_sys::CURLMOPT_PIPELINING, bitmask)
+    }
+
+    fn setopt_long(&mut self,
+                   opt: curl_sys::CURLMoption,
+                   val: c_long) -> Result<(), MultiError> {
+        unsafe {
+            cvt(curl_sys::curl_multi_setopt(self.raw, opt, val))
+        }
+    }
+
     fn setopt_ptr(&mut self,
                   opt: curl_sys::CURLMoption,
                   val: *const c_char) -> Result<(), MultiError> {

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -45,13 +45,16 @@ fn main() {
     });
 
     cfg.skip_const(|s| {
-        // Ubuntu Xenial 16.04 ships with version 7.47.0 of curl, so explicitly
-        // skip constants introduced after that.
+        // Ubuntu 14.04 (Trusty) which we test on ships with version 7.35.0 of
+        // curl, so explicitly skip constants introduced after that.
         // CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE was introduced in 7.49.0
         s == "CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE" ||
 
         // OSX doesn't have this yet
         s == "CURLSSLOPT_NO_REVOKE" ||
+
+        // CURLPIPE helpers were added in 7.43.0
+        s.starts_with("CURLPIPE_") ||
 
         // Disable HTTP/2 checking if feature not enabled
         (!cfg!(feature = "http2") && s.starts_with("CURL_HTTP_VERSION_2")) ||


### PR DESCRIPTION
The docs are mostly copied from https://curl.haxx.se/libcurl/c/CURLMOPT_PIPELINING.html.