### PR TITLE
fix test on macOSX environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ kernel32-sys = "0.2"
 
 [dev-dependencies]
 mio = "0.6"
+mio-extras = "2.0.3"
 
 [workspace]
 members = ["systest"]

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -2,6 +2,7 @@
 
 extern crate curl;
 extern crate mio;
+extern crate mio_extras;
 
 use std::collections::HashMap;
 use std::io::{Read, Cursor};
@@ -91,7 +92,7 @@ fn upload_lots() {
 
     let mut m = Multi::new();
     let poll = t!(mio::Poll::new());
-    let (tx, rx) = mio::channel::channel();
+    let (tx, rx) = mio_extras::channel::channel();
     let tx2 = tx.clone();
     t!(m.socket_function(move |socket, events, token| {
         t!(tx2.send(Message::Wait(socket, events, token)));


### PR DESCRIPTION
### Error Summary
error log:
```
test result: ok. 28 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

     Running target/x86_64-apple-darwin/debug/deps/multi-c453e94ed395bda6

running 3 tests
test smoke ... ok
test smoke2 ... ok
thread '<unnamed>' panicked at 'unexpected header: "" (remaining headers {"Accept: */*\r\n", "\r\n", "Content-Length: 131072\r\n", "PUT / HTTP/1.1\r\n", "Host: 127.0.0.1:54854\r\n"})', tests/server/mod.rs:64:21
test upload_lots ... FAILED

failures:

---- upload_lots stdout ----
	thread 'upload_lots' panicked at 'assertion failed: interest <= MASK_4', /Users/hattori-h/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.6.14/src/poll.rs:2538:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
child server thread also failed: Any


failures:
    upload_lots

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--test multi'
```
* error occured when run `TARGET=x86_64-apple-darwin sh ci/run.sh` command.
* mac 10.12.6 and same error on TravisCI environment.
* `mio` crate version up to `0.6.14` from `0.6.13`

### Change Summary
* using mio-extras crate