### PR TITLE
fix(cargo): Update minimal dependency versions so that 'cargo build -Z minimal-versions' works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 [dependencies]
 libc = "0.2"
 curl-sys = { path = "curl-sys", version = "0.4.1" }
-socket2 = "0.3"
+socket2 = "0.3.2"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -20,8 +20,8 @@ name = "curl_sys"
 path = "lib.rs"
 
 [dependencies]
-libz-sys = ">= 0"
-libc = "0.2"
+libz-sys = "0.1.2"
+libc = "0.2.2"
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
 openssl-sys = "0.9"
@@ -33,5 +33,5 @@ winapi = { version = "0.3", features = ["winsock2", "ws2def"] }
 vcpkg = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.2"
 cc = "1.0"


### PR DESCRIPTION
The create does not compile with `cargo build -Z minimal-versions` because a lot of minimal versions are underspecified. I bumped them until I could build successfully.

Ideally we should also add something like `cargo update -Z minimal-versions && cargo build` to the Travis CI config so that this does not happen again in the future. I'm not sure where to put that exactly?