### PR TITLE
fix(cargo): Install highest possible libz-sys dependency version

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -20,7 +20,7 @@ name = "curl_sys"
 path = "lib.rs"
 
 [dependencies]
-libz-sys = "0.1.2"
+libz-sys = ">= 0.1.2"
 libc = "0.2.2"
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]


### PR DESCRIPTION
Follow-up to #205 .

Sorry, I thought that "0.1.2" would allow any later version, but cargo interprets that as 0.1.x only. We want libz-sys 1.x also.