### PR TITLE
Manifest: add excludes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ homepage = "https://github.com/alexcrichton/curl-rust"
 documentation = "https://docs.rs/curl"
 description = "Rust bindings to libcurl for making HTTP requests"
 categories = ["api-bindings", "web-programming::http-client"]
+exclude = [
+    "curl/tests/*",
+    "curl/docs/*",
+]
 
 [badges]
 travis-ci = { repository = "alexcrichton/curl-rust" }


### PR DESCRIPTION
These are two of the biggest data directories that get extracted to Cargo cache, but they are not actually useful. Exclude them when publishing.