### PR TITLE
added support for CURLINFO_CONTENT_LENGTH_DOWNLOAD

### DIFF
--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -1038,6 +1038,10 @@ impl Easy {
     pub fn download_size(&mut self) -> Result<f64, Error> {
         self.inner.download_size()
     }
+    /// Same as [`Easy2::content_length_download`](struct.Easy2.html#method.content_length_download)
+    pub fn content_length_download(&mut self) -> Result<f64, Error> {
+        self.inner.content_length_download()
+    }
 
     /// Same as [`Easy2::total_time`](struct.Easy2.html#method.total_time)
     pub fn total_time(&mut self) -> Result<Duration, Error> {

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -2291,6 +2291,18 @@ impl<H> Easy2<H> {
             .map(|r| r as f64)
     }
 
+    /// Get the content-length of the download
+    ///
+    /// Returns the content-length of the download.
+    /// This is the value read from the Content-Length: field
+    ///
+    /// This corresponds to `CURLINFO_CONTENT_LENGTH_DOWNLOAD` and may return an error if the
+    /// option is not supported
+    pub fn content_length_download(&mut self) -> Result<f64, Error> {
+        self.getopt_double(curl_sys::CURLINFO_CONTENT_LENGTH_DOWNLOAD)
+            .map(|r| r as f64)
+    }
+
     /// Get total time of previous transfer
     ///
     /// Returns the total time for the previous transfer,


### PR DESCRIPTION
Hi, I needed this CURLINFO_CONTENT_LENGTH_DOWNLOAD option in my binary, so I just added it

but I'm very new to rust, like less than a week, so if you can please review this PR I would appreciate

thanks