### PR TITLE
get curl working with its minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ openssl-sys = "0.9.0"
 openssl-probe = "0.1"
 
 [target."cfg(windows)".dependencies]
-winapi = "0.2"
+winapi = "0.2.7"
 
 [target.'cfg(target_env="msvc")'.dependencies]
 schannel = "0.1.8"

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -33,5 +33,5 @@ winapi = { version = "0.3", features = ["winsock2", "ws2def"] }
 vcpkg = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3.2"
+pkg-config = "0.3.3"
 cc = "1.0"


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that build on modern rust. this gets curl and curl-sys working with Cargos -Z minimal-versions. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them. This is a follow up to https://github.com/alexcrichton/git2-rs/pull/336