### PR TITLE
Point docs for Transfer::perform to Easy::perform

### DIFF
--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -1418,7 +1418,7 @@ impl<'easy, 'data> Transfer<'easy, 'data> {
         Ok(())
     }
 
-    /// Same as `Easy::transfer`.
+    /// Same as `Easy::perform`.
     pub fn perform(&self) -> Result<(), Error> {
         let inner = self.easy.inner.get_ref();
 


### PR DESCRIPTION
The docs for `Transfer::perform` erroneously said that it was the same as `Easy::transfer`. This should point to `Easy::perform` instead.