### PR TITLE
Make the openssl dependency optional (with default on).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ mio-extras = "2.0.3"
 members = ["systest"]
 
 [features]
-default = ['openssl']
-openssl = ['openssl-sys', 'openssl-probe', 'curl-sys/openssl']
+default = ['ssl']
+ssl = ['openssl-sys', 'openssl-probe', 'curl-sys/ssl']
 http2 = ['curl-sys/http2']
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 
 [dependencies]
 libc = "0.2.42"
-curl-sys = { path = "curl-sys", version = "0.4.9" }
+curl-sys = { path = "curl-sys", version = "0.4.9" , default-features = false}
 socket2 = "0.3.7"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
-openssl-sys = "0.9.33"
-openssl-probe = "0.1.2"
+openssl-sys = { version = "0.9.33", optional = true }
+openssl-probe = { version = "0.1.2", optional = true }
 
 [target."cfg(windows)".dependencies]
 winapi = "0.2.7"
@@ -39,6 +39,8 @@ mio-extras = "2.0.3"
 members = ["systest"]
 
 [features]
+default = ['openssl']
+openssl = ['openssl-sys', 'openssl-probe', 'curl-sys/openssl']
 http2 = ['curl-sys/http2']
 
 [[test]]

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1" }
 
 [target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
-openssl-sys = "0.9"
+openssl-sys = { version = "0.9", optional = true}
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["winsock2", "ws2def"] }
@@ -38,4 +38,6 @@ pkg-config = "0.3.3"
 cc = "1.0"
 
 [features]
+default = ['openssl']
+openssl = ['openssl-sys']
 http2 = ['libnghttp2-sys']

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -38,6 +38,6 @@ pkg-config = "0.3.3"
 cc = "1.0"
 
 [features]
-default = ['openssl']
-openssl = ['openssl-sys']
+default = ['ssl']
+ssl = ['openssl-sys']
 http2 = ['libnghttp2-sys']

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -209,7 +209,6 @@ fn main() {
             .define("HAVE_STERRROR_R", None)
             .define("HAVE_STRUCT_TIMEVAL", None)
             .define("USE_THREADS_POSIX", None)
-            .define("USE_OPENSSL", None)
             .define("RECV_TYPE_ARG2", "void*")
             .define("RECV_TYPE_ARG3", "size_t")
             .define("RECV_TYPE_ARG4", "int")
@@ -222,8 +221,16 @@ fn main() {
             .define("SEND_TYPE_RETV", "ssize_t")
             .define("SIZEOF_CURL_OFF_T", "8")
             .define("SIZEOF_INT", "4")
-            .define("SIZEOF_SHORT", "2")
-            .file("curl/lib/vtls/openssl.c");
+            .define("SIZEOF_SHORT", "2");
+
+        if cfg!(feature = "openssl") {
+            cfg.define("USE_OPENSSL", None)
+                .file("curl/lib/vtls/openssl.c");
+
+            if let Some(path) = env::var_os("DEP_OPENSSL_INCLUDE") {
+                cfg.include(path);
+            }
+        }
 
         let width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH")
             .unwrap()
@@ -232,10 +239,6 @@ fn main() {
         cfg.define("SIZEOF_SSIZE_T", Some(&(width / 8).to_string()[..]));
         cfg.define("SIZEOF_SIZE_T", Some(&(width / 8).to_string()[..]));
         cfg.define("SIZEOF_LONG", Some(&(width / 8).to_string()[..]));
-
-        if let Some(path) = env::var_os("DEP_OPENSSL_INCLUDE") {
-            cfg.include(path);
-        }
 
         cfg.flag("-fvisibility=hidden");
     }

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -179,15 +179,18 @@ fn main() {
     if windows {
         cfg.define("USE_THREADS_WIN32", None)
             .define("HAVE_IOCTLSOCKET_FIONBIO", None)
-            .define("USE_WINSOCK", None)
-            .define("USE_WINDOWS_SSPI", None)
-            .define("USE_SCHANNEL", None)
-            .file("curl/lib/x509asn1.c")
-            .file("curl/lib/curl_sspi.c")
-            .file("curl/lib/socks_sspi.c")
-            .file("curl/lib/system_win32.c")
-            .file("curl/lib/vtls/schannel.c")
-            .file("curl/lib/vtls/schannel_verify.c");
+            .define("USE_WINSOCK", None);
+
+        if cfg!(feature = "ssl") {
+            cfg.define("USE_WINDOWS_SSPI", None)
+                .define("USE_SCHANNEL", None)
+                .file("curl/lib/x509asn1.c")
+                .file("curl/lib/curl_sspi.c")
+                .file("curl/lib/socks_sspi.c")
+                .file("curl/lib/system_win32.c")
+                .file("curl/lib/vtls/schannel.c")
+                .file("curl/lib/vtls/schannel_verify.c");
+        }
     } else {
         cfg.define("RECV_TYPE_ARG1", "int")
             .define("HAVE_PTHREAD_H", None)
@@ -223,7 +226,7 @@ fn main() {
             .define("SIZEOF_INT", "4")
             .define("SIZEOF_SHORT", "2");
 
-        if cfg!(feature = "openssl") {
+        if cfg!(feature = "ssl") {
             cfg.define("USE_OPENSSL", None)
                 .file("curl/lib/vtls/openssl.c");
 

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -179,7 +179,8 @@ fn main() {
     if windows {
         cfg.define("USE_THREADS_WIN32", None)
             .define("HAVE_IOCTLSOCKET_FIONBIO", None)
-            .define("USE_WINSOCK", None);
+            .define("USE_WINSOCK", None)
+            .file("curl/lib/system_win32.c");
 
         if cfg!(feature = "ssl") {
             cfg.define("USE_WINDOWS_SSPI", None)
@@ -187,7 +188,6 @@ fn main() {
                 .file("curl/lib/x509asn1.c")
                 .file("curl/lib/curl_sspi.c")
                 .file("curl/lib/socks_sspi.c")
-                .file("curl/lib/system_win32.c")
                 .file("curl/lib/vtls/schannel.c")
                 .file("curl/lib/vtls/schannel_verify.c");
         }

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate libc;
 extern crate libz_sys;
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
 extern crate openssl_sys;
 #[cfg(windows)]
 extern crate winapi;

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate libc;
 extern crate libz_sys;
-#[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
+#[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
 extern crate openssl_sys;
 #[cfg(windows)]
 extern crate winapi;

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -696,7 +696,7 @@ impl<H: Handler> Easy2<H> {
             .expect("failed to set open socket callback");
     }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
     fn ssl_configure(&mut self) {
         let probe = ::openssl_probe::probe();
         if let Some(ref path) = probe.cert_file {
@@ -707,7 +707,7 @@ impl<H: Handler> Easy2<H> {
         }
     }
 
-    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    #[cfg(not(all(unix, not(target_os = "macos"), feature = "openssl")))]
     fn ssl_configure(&mut self) {}
 }
 

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -696,7 +696,7 @@ impl<H: Handler> Easy2<H> {
             .expect("failed to set open socket callback");
     }
 
-    #[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
+    #[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
     fn ssl_configure(&mut self) {
         let probe = ::openssl_probe::probe();
         if let Some(ref path) = probe.cert_file {
@@ -707,7 +707,7 @@ impl<H: Handler> Easy2<H> {
         }
     }
 
-    #[cfg(not(all(unix, not(target_os = "macos"), feature = "openssl")))]
+    #[cfg(not(all(unix, not(target_os = "macos"), feature = "ssl")))]
     fn ssl_configure(&mut self) {}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,9 @@ extern crate curl_sys;
 extern crate libc;
 extern crate socket2;
 
-#[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
+#[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
 extern crate openssl_sys;
-#[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
+#[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
 extern crate openssl_probe;
 #[cfg(windows)]
 extern crate winapi;
@@ -103,12 +103,12 @@ pub fn init() {
         // function.
     });
 
-    #[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
+    #[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
     fn platform_init() {
         openssl_sys::init();
     }
 
-    #[cfg(not(all(unix, not(target_os = "macos"), feature = "openssl")))]
+    #[cfg(not(all(unix, not(target_os = "macos"), feature = "ssl")))]
     fn platform_init() {}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,9 @@ extern crate curl_sys;
 extern crate libc;
 extern crate socket2;
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
 extern crate openssl_sys;
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
 extern crate openssl_probe;
 #[cfg(windows)]
 extern crate winapi;
@@ -103,12 +103,12 @@ pub fn init() {
         // function.
     });
 
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(all(unix, not(target_os = "macos"), feature = "openssl"))]
     fn platform_init() {
         openssl_sys::init();
     }
 
-    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    #[cfg(not(all(unix, not(target_os = "macos"), feature = "openssl")))]
     fn platform_init() {}
 }
 


### PR DESCRIPTION
For work-reasons we want to use curl without `openssl` support (mostly to save binary sizes). This pull requests just makes `openssl` optional under a feature with the same name.