### PR TITLE
Cargo features for enabling static linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,18 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 
 [dependencies]
 libc = "0.2.42"
-curl-sys = { path = "curl-sys", version = "0.4.9" , default-features = false}
+curl-sys = { path = "curl-sys", version = "0.4.9", default-features = false }
 socket2 = "0.3.7"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
-[target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 openssl-sys = { version = "0.9.33", optional = true }
 openssl-probe = { version = "0.1.2", optional = true }
 
-[target."cfg(windows)".dependencies]
+[target.'cfg(windows)'.dependencies]
 winapi = "0.2.7"
 
-[target.'cfg(target_env="msvc")'.dependencies]
+[target.'cfg(target_env = "msvc")'.dependencies]
 schannel = "0.1.13"
 kernel32-sys = "0.2.2"
 
@@ -39,9 +39,11 @@ mio-extras = "2.0.3"
 members = ["systest"]
 
 [features]
-default = ['ssl']
-ssl = ['openssl-sys', 'openssl-probe', 'curl-sys/ssl']
-http2 = ['curl-sys/http2']
+default = ["ssl"]
+ssl = ["openssl-sys", "openssl-probe", "curl-sys/ssl"]
+http2 = ["curl-sys/http2"]
+static-curl = ["curl-sys/static-curl"]
+static-ssl = ["curl-sys/static-ssl"]
 
 [[test]]
 name = "atexit"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ simultaneously through the "multi" interface. This is currently bound in the
 `multi` module of this crate and provides the ability to execute multiple
 transfers simultaneously. For more information, see that module.
 
+## Building
+
+By default, this crate will attempt to dynamically link to the system-wide
+libcurl and the system-wide SSL library. Some of this behavior can be customized
+with various Cargo features:
+
+- `ssl`: Enable SSL support. Enabled by default.
+- `http2`: Enable HTTP/2 support via libnghttp2. Disabled by default.
+- `static-curl`: Use a bundled libcurl version and statically link to it. Disabled by default.
+- `static-ssl`: Use a bundled OpenSSL version and statically link to it. Only applies on platforms that use OpenSSL. Disabled by default.
+
 ## Version Support
 
 The bindings have been developed using curl version 7.24.0. They should

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -24,10 +24,10 @@ libz-sys = "1.0.18"
 libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1" }
 
-[target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
-openssl-sys = { version = "0.9", optional = true}
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+openssl-sys = { version = "0.9", optional = true }
 
-[target."cfg(windows)".dependencies]
+[target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winsock2", "ws2def"] }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
@@ -38,6 +38,8 @@ pkg-config = "0.3.3"
 cc = "1.0"
 
 [features]
-default = ['ssl']
-ssl = ['openssl-sys']
-http2 = ['libnghttp2-sys']
+default = ["ssl"]
+ssl = ["openssl-sys"]
+http2 = ["libnghttp2-sys"]
+static-curl = []
+static-ssl = ["openssl-sys/vendored"]

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -12,20 +12,23 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     let windows = target.contains("windows");
 
-    // OSX and Haiku ships libcurl by default, so we just use that version
-    // unconditionally.
-    if target.contains("apple") || target.contains("haiku") {
-        return println!("cargo:rustc-flags=-l curl");
-    }
-
-    // Next, fall back and try to use pkg-config if its available.
-    if windows {
-        if try_vcpkg() {
-            return
+    // If the static-curl feature is disabled, probe for a system-wide libcurl.
+    if !cfg!(feature = "static-curl") {
+        // OSX and Haiku ships libcurl by default, so we just use that version
+        // unconditionally.
+        if target.contains("apple") || target.contains("haiku") {
+            return println!("cargo:rustc-flags=-l curl");
         }
-    } else {
-        if try_pkg_config() {
-            return
+
+        // Next, fall back and try to use pkg-config if its available.
+        if windows {
+            if try_vcpkg() {
+                return
+            }
+        } else {
+            if try_pkg_config() {
+                return
+            }
         }
     }
 


### PR DESCRIPTION
Add two new Cargo features, static-curl and static-ssl, for unconditionally statically linking to bundled versions of libcurl and libssl respectively.

Addresses #148.