### PR TITLE
Bump curl-sys to 0.4.13

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Carl Lerche <me@carllerche.com>",
            "Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"


### PR DESCRIPTION
I'm thoroughly confused, as the commit at https://github.com/alexcrichton/curl-rust/commit/2783a574e5fbcf722387b70ec792ecfc0f79f367 doesn't seem to exist on any branch.  I was trying to `[patch]` it and took me a bit to figure out why my version was out of date.