### PR TITLE
Support HTTP/2 on static curl-sys on MacOS.

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -242,6 +242,7 @@ fn main() {
         if cfg!(feature = "ssl") {
             if target.contains("-apple-") {
                 cfg.define("USE_DARWINSSL", None)
+                    .define("HAVE_BUILTIN_AVAILABLE", "1")
                     .file("curl/lib/vtls/darwinssl.c");
             } else {
                 cfg.define("USE_OPENSSL", None)


### PR DESCRIPTION
Ever since rust started using static builds (rust-lang/rust#54919), HTTP/2 hasn't been working on MacOS. The static feature is using the darwinssl backend, which looks like it needs a define to enable some conditional logic to enable ALPN to detect if HTTP/2 is available.

I have no idea if this is safe/wise, but in limited testing on my 10.14 system it seems to work. IIUC, rustc builds on 10.13, so I think these should still apply there.  I think `__builtin_available` was introduced in Xcode 9, but I'm not sure.