### PR TITLE
Do not mention *_sys crates if they are not needed.

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -178,12 +178,14 @@ fn main() {
         cfg.define("USE_NGHTTP2", None)
             .define("NGHTTP2_STATICLIB", None);
 
+        println!("cargo:rustc-cfg=link_libnghttp2");
         if let Some(path) = env::var_os("DEP_NGHTTP2_ROOT") {
             let path = PathBuf::from(path);
             cfg.include(path.join("include"));
         }
     }
 
+    println!("cargo:rustc-cfg=link_libz");
     if let Some(path) = env::var_os("DEP_Z_INCLUDE") {
         cfg.include(path);
     }
@@ -263,6 +265,7 @@ fn main() {
                 cfg.define("USE_OPENSSL", None)
                     .file("curl/lib/vtls/openssl.c");
 
+                println!("cargo:rustc-cfg=link_openssl");
                 if let Some(path) = env::var_os("DEP_OPENSSL_INCLUDE") {
                     cfg.include(path);
                 }

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -2,13 +2,14 @@
 #![doc(html_root_url = "https://docs.rs/curl-sys/0.3")]
 
 extern crate libc;
+#[cfg(link_libz)]
 extern crate libz_sys;
-#[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
+#[cfg(link_openssl)]
 extern crate openssl_sys;
+#[cfg(link_libnghttp2)]
+extern crate libnghttp2_sys;
 #[cfg(windows)]
 extern crate winapi;
-#[cfg(feature = "http2")]
-extern crate libnghttp2_sys;
 
 use libc::{c_int, c_char, c_uint, c_short, c_long, c_double, c_void, size_t, time_t};
 use libc::c_ulong;


### PR DESCRIPTION
They are only used so that the corresponding native libraries are linked
in to the static cURL library. This is not needed when building against
the system library:
  - If it's a shared library, it is linked against them already and they
 are not a part of the public interface.
  - Both pkgconfig and vcpkg deal with these dependencies and provide
  the right link args to cargo.