### PR TITLE
Remove unnecessary call to openssl_sys::init()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - os: linux
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu DOCKER=linux64-curl NO_ADD=1
+    - os: linux
+      rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu DOCKER=centos7 NO_ADD=1
     - os: osx
       rust: stable
       env: TARGET=x86_64-apple-darwin NO_ADD=1

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::str::FromStr;
+
+fn main() {
+    // OpenSSL >= 1.1.0 can be initialized concurrently and is initialized correctly by libcurl.
+    // <= 1.0.2 need locking callbacks, which are provided by openssl_sys::init().
+    match env::var("DEP_OPENSSL_VERSION") {
+        Ok(ver) => {
+            let ver = u32::from_str(&ver).unwrap();
+            if ver < 110 {
+                println!("cargo:rustc-cfg=need_openssl_init");
+            }
+        }
+        Err(env::VarError::NotPresent) => {}
+        Err(e) => panic!(e),
+    }
+
+    // The system libcurl should have the default certificate paths configured.
+    match env::var("DEP_CURL_STATIC") {
+        Ok(_) => {
+            println!("cargo:rustc-cfg=need_openssl_probe");
+        }
+        Err(env::VarError::NotPresent) => {}
+        Err(e) => panic!(e),
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -2,25 +2,32 @@ use std::env;
 use std::str::FromStr;
 
 fn main() {
+    let use_openssl;
+
     // OpenSSL >= 1.1.0 can be initialized concurrently and is initialized correctly by libcurl.
     // <= 1.0.2 need locking callbacks, which are provided by openssl_sys::init().
     match env::var("DEP_OPENSSL_VERSION") {
         Ok(ver) => {
+            use_openssl = true;
             let ver = u32::from_str(&ver).unwrap();
             if ver < 110 {
                 println!("cargo:rustc-cfg=need_openssl_init");
             }
+
         }
-        Err(env::VarError::NotPresent) => {}
+        Err(env::VarError::NotPresent) => {
+            use_openssl = false;
+        }
         Err(e) => panic!(e),
     }
 
-    // The system libcurl should have the default certificate paths configured.
-    match env::var("DEP_CURL_STATIC") {
-        Ok(_) => {
-            println!("cargo:rustc-cfg=need_openssl_probe");
+    if use_openssl {
+        // The system libcurl should have the default certificate paths configured.
+        match env::var_os("DEP_CURL_STATIC") {
+            Some(_) => {
+                println!("cargo:rustc-cfg=need_openssl_probe");
+            }
+            None => {}
         }
-        Err(env::VarError::NotPresent) => {}
-        Err(e) => panic!(e),
     }
 }

--- a/ci/Dockerfile-centos7
+++ b/ci/Dockerfile-centos7
@@ -1,0 +1,7 @@
+FROM centos:7
+
+RUN yum update -y
+RUN yum install -y \
+  gcc ca-certificates make \
+  openssl-devel \
+  pkgconfig

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -697,7 +697,7 @@ impl<H: Handler> Easy2<H> {
             .expect("failed to set open socket callback");
     }
 
-    #[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
+    #[cfg(need_openssl_probe)]
     fn ssl_configure(&mut self) {
         let probe = ::openssl_probe::probe();
         if let Some(ref path) = probe.cert_file {
@@ -708,7 +708,7 @@ impl<H: Handler> Easy2<H> {
         }
     }
 
-    #[cfg(not(all(unix, not(target_os = "macos"), feature = "ssl")))]
+    #[cfg(not(need_openssl_probe))]
     fn ssl_configure(&mut self) {}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,11 @@ extern crate curl_sys;
 extern crate libc;
 extern crate socket2;
 
-#[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
+#[cfg(need_openssl_init)]
 extern crate openssl_sys;
-#[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
+#[cfg(need_openssl_probe)]
 extern crate openssl_probe;
+
 #[cfg(windows)]
 extern crate winapi;
 
@@ -103,12 +104,12 @@ pub fn init() {
         // function.
     });
 
-    #[cfg(all(unix, not(target_os = "macos"), feature = "ssl"))]
+    #[cfg(need_openssl_init)]
     fn platform_init() {
         openssl_sys::init();
     }
 
-    #[cfg(not(all(unix, not(target_os = "macos"), feature = "ssl")))]
+    #[cfg(not(need_openssl_init))]
     fn platform_init() {}
 }
 


### PR DESCRIPTION
curl_global_init() alreary initializes OpenSSL correctly.