### PR TITLE
README.md: add troubleshooting section with NSS SSL hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,28 @@ The bindings have been developed using curl version 7.24.0. They should
 work with any newer version of curl and possibly with older versions,
 but this has not been tested.
 
+## Troubleshooting
+
+### Curl built against the NSS SSL library
+
+If you encounter the following error message:
+
+```
+  [77] Problem with the SSL CA cert (path? access rights?)
+```
+
+That means most likely, that curl was linked against `libcurl-nss.so` due to
+installed libcurl NSS development files, and that the required library
+`libnsspem.so` is missing. See also the curl man page: "If curl is built
+against the NSS SSL library, the NSS PEM PKCS#11 module (libnsspem.so) needs to
+be available for this option to work properly."
+
+In order to avoid this failure you can either
+
+ * install the missing library (e.g. Debian: `nss-plugin-pem`), or
+ * remove the libcurl NSS development files (e.g. Debian: `libcurl4-nss-dev`) and
+   rebuild curl-rust.
+
 ## License
 
 The `curl-rust` crate is licensed under the MIT license, see `LICENSE` for more


### PR DESCRIPTION
As discussed in the cargo-vendor context.
If you think that the hint is also too prominent here, I can create a separate troubleshooting file.

Thank you very much for creating and maintaining such crucial crates besides all your other work.