### PR TITLE
derive Clone for ProxyType

### DIFF
--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -392,7 +392,7 @@ unsafe impl<H: Send> Send for Inner<H> {}
 
 /// Possible proxy types that libcurl currently understands.
 #[allow(missing_docs)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ProxyType {
     Http = curl_sys::CURLPROXY_HTTP as isize,
     Http1 = curl_sys::CURLPROXY_HTTP_1_0 as isize,

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -392,7 +392,7 @@ unsafe impl<H: Send> Send for Inner<H> {}
 
 /// Possible proxy types that libcurl currently understands.
 #[allow(missing_docs)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ProxyType {
     Http = curl_sys::CURLPROXY_HTTP as isize,
     Http1 = curl_sys::CURLPROXY_HTTP_1_0 as isize,


### PR DESCRIPTION
Now there have no comfortable way to set proxy type for more than one handler since `Easy::proxy_type` takes the ownership of a `ProxyType` enum. Deriving a `Clone` trait for `ProxyType` ensures such code possible:
``` rust
let proxy = read_proxy_type();
let handler1 = Easy::new();
let handler2 = Easy::new();
handler1.proxy_type(proxy.clone());
handler2.proxy_type(proxy.clone());
```
It will be better to modify the `Easy::proxy_type` function itself. But deriving a `Clone` trait is not harmful.