### PR TITLE
Static OpenSSL Linking for MacOS and Windows

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -22,8 +22,6 @@ path = "lib.rs"
 libz-sys = "1.0.18"
 libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1" }
-
-[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 openssl-sys = { version = "0.9", optional = true }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
I made some `build.rs` updates to support statically linking openssl + curl on MacOS and Windows. Previously, this worked flawlessly against musl on linux, but the other platforms still required extern dependencies once compiled.

I tried to keep the changes as minimal as possible, and if there is a better way to accomplish this please just let me know.

I use `curl-rust` in production and have to support many platforms. Sometimes we run into old XP systems that don't support TLS natively and thus statically bringing openssl in a fat binary is the only way to achieve communications. Similarly on MacOS, I'm not able to guarantee the presence or version of a dynamically linked openssl version on the host.

I used the example app from the README and this feature set to produce binaries for windows and MacOS to verify the changes work.

_Note:_ originally i had introduced a completely separate feature flag for forcing this as to leave the current behavior in tact. I decided against it eventually but can definitely bring it back if so desired.