### PR TITLE
Link against clang runtime on static builds on macOS

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -493,9 +493,14 @@ fn curl_config_reports_http2() -> bool {
 }
 
 fn macos_link_search_path() -> Option<String> {
-    let output = Command::new("clang").arg("--print-search-dirs").output().ok()?;
+    let output = Command::new("clang")
+        .arg("--print-search-dirs")
+        .output()
+        .ok()?;
     if !output.status.success() {
-        println!("failed to run 'clang --print-search-dirs', continuing without a link search path");
+        println!(
+            "failed to run 'clang --print-search-dirs', continuing without a link search path"
+        );
         return None;
     }
 

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -47,6 +47,17 @@ fn main() {
             .status();
     }
 
+    if target.contains("apple") {
+        // On (older) OSX we need to link against the clang runtime,
+        // which is hidden in some non-default path.
+        //
+        // More details at https://github.com/alexcrichton/curl-rust/issues/279.
+        if let Some(path) = macos_link_search_path() {
+            println!("cargo:rustc-link-lib=clang_rt.osx");
+            println!("cargo:rustc-link-search={}", path);
+        }
+    }
+
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let include = dst.join("include");
     let build = dst.join("build");
@@ -479,4 +490,23 @@ fn curl_config_reports_http2() -> bool {
     }
 
     return true;
+}
+
+fn macos_link_search_path() -> Option<String> {
+    let output = Command::new("clang").arg("--print-search-dirs").output().ok()?;
+    if !output.status.success() {
+        println!("failed to run 'clang --print-search-dirs', continuing without a link search path");
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if line.contains("libraries: =") {
+            let path = line.split('=').skip(1).next()?;
+            return Some(format!("{}/lib/darwin", path));
+        }
+    }
+
+    println!("failed to determine link search path, continuing without it");
+    None
 }


### PR DESCRIPTION
On OSX we need to link against the clang runtime, which is hidden in some non-default path.
We can get the path from `clang --print-search-dirs`.
Kudos to @ehuss for finding that workaround.

Fixes #279.