### PR TITLE
add .git suffix to the submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "curl-sys/curl"]
 	path = curl-sys/curl
-	url = https://github.com/curl/curl
+	url = https://github.com/curl/curl.git


### PR DESCRIPTION
to make it point to the actual git link. though github would directly it properly... this is more likely a style fix.