### PR TITLE
Fix the one warning on Windows

### DIFF
--- a/src/easy/windows.rs
+++ b/src/easy/windows.rs
@@ -88,7 +88,7 @@ mod win {
         };
 
         let openssl_store = (openssl.SSL_CTX_get_cert_store)(ssl_ctx as *const SSL_CTX);
-        let mut store = match CertStore::open_current_user("ROOT") {
+        let store = match CertStore::open_current_user("ROOT") {
             Ok(s) => s,
             Err(_) => return,
         };


### PR DESCRIPTION
Fix following warning on Windows:

```
  --> src\easy\windows.rs:91:13
   |
91 |         let mut store = match CertStore::open_current_user("ROOT") {
   |             ----^^^^^
   |             |
   |             help: remove this `mut`
   |
   = note: #[warn(unused_mut)] on by default
```