### PR TITLE
Remove `winapi 0.2` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,9 @@ socket2 = "0.3.7"
 openssl-sys = { version = "0.9.43", optional = true }
 openssl-probe = { version = "0.1.2", optional = true }
 
-[target.'cfg(windows)'.dependencies]
-winapi = "0.2.7"
-
 [target.'cfg(target_env = "msvc")'.dependencies]
 schannel = "0.1.13"
-kernel32-sys = "0.2.2"
+winapi = { version = '0.3', features = ['libloaderapi', 'wincrypt'] }
 
 [dev-dependencies]
 mio = "0.6"

--- a/src/easy/windows.rs
+++ b/src/easy/windows.rs
@@ -4,25 +4,27 @@ use libc::c_void;
 
 #[cfg(target_env = "msvc")]
 mod win {
-    use kernel32;
+    extern crate winapi;
     use schannel::cert_context::ValidUses;
     use schannel::cert_store::CertStore;
     use std::ffi::CString;
     use std::mem;
     use std::ptr;
-    use winapi::{self, c_int, c_long, c_uchar, c_void};
+    use self::winapi::ctypes::*;
+    use self::winapi::um::libloaderapi::*;
+    use self::winapi::um::wincrypt::*;
 
     fn lookup(module: &str, symbol: &str) -> Option<*const c_void> {
         unsafe {
             let symbol = CString::new(symbol).unwrap();
             let mut mod_buf: Vec<u16> = module.encode_utf16().collect();
             mod_buf.push(0);
-            let handle = kernel32::GetModuleHandleW(mod_buf.as_mut_ptr());
-            let n = kernel32::GetProcAddress(handle, symbol.as_ptr());
-            if n == ptr::null() {
+            let handle = GetModuleHandleW(mod_buf.as_mut_ptr());
+            let n = GetProcAddress(handle, symbol.as_ptr());
+            if n == ptr::null_mut() {
                 None
             } else {
-                Some(n)
+                Some(n as *const c_void)
             }
         }
     }
@@ -103,7 +105,7 @@ mod win {
             match valid_uses {
                 ValidUses::All => {}
                 ValidUses::Oids(ref oids) => {
-                    let oid = winapi::wincrypt::szOID_PKIX_KP_SERVER_AUTH.to_owned();
+                    let oid = szOID_PKIX_KP_SERVER_AUTH.to_owned();
                     if !oids.contains(&oid) {
                         continue;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,6 @@ extern crate openssl_probe;
 #[cfg(need_openssl_init)]
 extern crate openssl_sys;
 
-#[cfg(windows)]
-extern crate winapi;
-
-#[cfg(target_env = "msvc")]
-extern crate kernel32;
 #[cfg(target_env = "msvc")]
 extern crate schannel;
 

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -8,9 +8,7 @@ use curl_sys;
 use libc::{c_char, c_int, c_long, c_short, c_void};
 
 #[cfg(unix)]
-use libc::{fd_set, pollfd, POLLIN, POLLOUT, POLLPRI};
-#[cfg(windows)]
-use winapi::winsock2::fd_set;
+use libc::{pollfd, POLLIN, POLLOUT, POLLPRI};
 
 use easy::{Easy, Easy2};
 use panic;
@@ -658,34 +656,6 @@ impl Multi {
             let except = except.map(|r| r as *mut _).unwrap_or(0 as *mut _);
             cvt(curl_sys::curl_multi_fdset(
                 self.raw, read, write, except, &mut ret,
-            ))?;
-            if ret == -1 {
-                Ok(None)
-            } else {
-                Ok(Some(ret))
-            }
-        }
-    }
-
-    #[doc(hidden)]
-    #[deprecated(note = "renamed to fdset2")]
-    pub fn fdset(
-        &self,
-        read: Option<&mut fd_set>,
-        write: Option<&mut fd_set>,
-        except: Option<&mut fd_set>,
-    ) -> Result<Option<i32>, MultiError> {
-        unsafe {
-            let mut ret = 0;
-            let read = read.map(|r| r as *mut _).unwrap_or(0 as *mut _);
-            let write = write.map(|r| r as *mut _).unwrap_or(0 as *mut _);
-            let except = except.map(|r| r as *mut _).unwrap_or(0 as *mut _);
-            cvt(curl_sys::curl_multi_fdset(
-                self.raw,
-                read as *mut _,
-                write as *mut _,
-                except as *mut _,
-                &mut ret,
             ))?;
             if ret == -1 {
                 Ok(None)


### PR DESCRIPTION
This commit removes the `winapi 0.2` dependency and also deletes the
`Multi::fdset` method. While technically a breaking change this was
deprecated 2 years ago at this point so I'm hoping that this crate can
practically get away with the breakage.