### PR TITLE
Enable HAVE_GETPEERNAME when building `curl`

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -187,6 +187,7 @@ fn main() {
         .file("curl/lib/warnless.c")
         .file("curl/lib/wildcard.c")
         .define("HAVE_GETADDRINFO", None)
+        .define("HAVE_GETPEERNAME", None)
         .warnings(false);
 
     if cfg!(feature = "http2") {


### PR DESCRIPTION
Looks like this enables a few optimizations internally, such as reusing
connections! Let's be sure to enable this for our platforms, which
should all have this, so we can get those performance optimizations with
HTTP.