### PR TITLE
Fix Curl_now() timer resolution

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -258,7 +258,8 @@ fn main() {
     }
 
     if windows {
-        cfg.define("USE_THREADS_WIN32", None)
+        cfg.define("WIN32", None)
+            .define("USE_THREADS_WIN32", None)
             .define("HAVE_IOCTLSOCKET_FIONBIO", None)
             .define("USE_WINSOCK", None)
             .file("curl/lib/system_win32.c");
@@ -267,7 +268,14 @@ fn main() {
             cfg.file("curl/lib/vauth/spnego_sspi.c");
         }
     } else {
+        if target.contains("-apple-") {
+            cfg.define("__APPLE__", None)
+                .define("macintosh", None);
+        }
+
         cfg.define("RECV_TYPE_ARG1", "int")
+            .define("HAVE_CLOCK_GETTIME_MONOTONIC", None)
+            .define("HAVE_GETTIMEOFDAY", None)
             .define("HAVE_PTHREAD_H", None)
             .define("HAVE_ARPA_INET_H", None)
             .define("HAVE_ERRNO_H", None)

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -269,8 +269,7 @@ fn main() {
         }
     } else {
         if target.contains("-apple-") {
-            cfg.define("__APPLE__", None)
-                .define("macintosh", None);
+            cfg.define("__APPLE__", None).define("macintosh", None);
         }
 
         cfg.define("RECV_TYPE_ARG1", "int")


### PR DESCRIPTION
Configure libcurl to use more accurate means of time measurement for use with various calculations, such as `CURLINFO_TOTAL_TIME`.