### PR TITLE
added unix-sockets feature support

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -233,6 +233,11 @@ fn main() {
             .file("curl/lib/vauth/vauth.c");
     }
 
+    if !windows {
+        cfg.define("USE_UNIX_SOCKETS", None)
+            .define("HAVE_SYS_UN_H", None);
+    }
+
     // Configure TLS backend. Since Cargo does not support mutually exclusive
     // features, make sure we only compile one vtls.
     if cfg!(feature = "mesalink") {


### PR DESCRIPTION
Related to https://github.com/alexcrichton/curl-rust/issues/297

Example:
```
let mut easy = Easy::new();
easy.unix_socket("/var/socket_path.sock")?;
easy.url("http://localhost/path")?;
```
