### PR TITLE
Improve support for older macOS versions

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -270,12 +270,15 @@ fn main() {
         }
     } else {
         if target.contains("-apple-") {
-            cfg.define("__APPLE__", None).define("macintosh", None);
+            cfg.define("__APPLE__", None)
+                .define("macintosh", None)
+                .define("HAVE_MACH_ABSOLUTE_TIME", None);
+        } else {
+            cfg.define("HAVE_CLOCK_GETTIME_MONOTONIC", None)
+                .define("HAVE_GETTIMEOFDAY", None);
         }
 
         cfg.define("RECV_TYPE_ARG1", "int")
-            .define("HAVE_CLOCK_GETTIME_MONOTONIC", None)
-            .define("HAVE_GETTIMEOFDAY", None)
             .define("HAVE_PTHREAD_H", None)
             .define("HAVE_ARPA_INET_H", None)
             .define("HAVE_ERRNO_H", None)


### PR DESCRIPTION
I tried running a binary built with the `static-curl` feature on macOS El Captian, and got the following error:

```
dyld: Symbol not found: _clock_gettime
  Referenced from: /..../my_binary (which was built for Mac OS X 10.13)
  Expected in: /usr/lib/libSystem.B.dylib
```

Apparently `clock_gettime` wasn't added until macOS 10.12.
There is a similar [issue](https://github.com/curl/curl/issues/2905) for `curl` which says to not define `HAVE_CLOCK_GETTIME_MONOTONIC`, so I changed this in the `build.rs` and everything seems to be working fine.

