### PR TITLE
Add an environment variable for requesting static linking with libcurl

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=CURL_SYS_STATIC");
+
     let target = env::var("TARGET").unwrap();
     let windows = target.contains("windows");
 
@@ -19,8 +21,10 @@ fn main() {
         return println!("cargo:rustc-flags=-l curl");
     }
 
-    // If the static-curl feature is disabled, probe for a system-wide libcurl.
-    if !cfg!(feature = "static-curl") {
+    let want_static =
+        cfg!(feature = "static-curl") || env::var("CURL_SYS_STATIC").as_ref() == Ok("1");
+    // If static linking is disabled, probe for a system-wide libcurl.
+    if !want_static {
         // OSX and Haiku ships libcurl by default, so we just use that version
         // so long as it has the right features enabled.
         if target.contains("apple") || target.contains("haiku") {

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -22,7 +22,7 @@ fn main() {
     }
 
     let want_static =
-        cfg!(feature = "static-curl") || env::var("CURL_SYS_STATIC").as_ref() == Ok("1");
+        cfg!(feature = "static-curl") || env::var("CURL_SYS_STATIC") == Ok("1".to_owned());
     // If static linking is disabled, probe for a system-wide libcurl.
     if !want_static {
         // OSX and Haiku ships libcurl by default, so we just use that version


### PR DESCRIPTION
Based on the exact same feature of `libz-sys` implemented here:

https://github.com/rust-lang/libz-sys/blob/510d1b6a8935d7de974a0bfb4d9764bae28bb474/build.rs#L24-L25

This is necessary to enabled/disable static linking based on the target platform, since Cargo doesn't support target-specific features for dependencies.

Also, since `curl-sys` depends on `libz-sys`, I think it would be also useful to make a feature called `static-libz` which enables the `static` feature in `libz-sys`. I can implement this in another PR.