### PR TITLE
Fix install of libkrb5-dev in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,9 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Install dependencies
-        run: sudo apt install libkrb5-dev
+        run: |
+          sudo apt update
+          sudo apt install libkrb5-dev
       - name: Build documentation
         run: cargo doc --no-deps --all-features
       - name: Publish documentation


### PR DESCRIPTION
I've found that sometimes the package server IP addresses are out of date on the Actions Ubuntu environments until you `apt update`. I noticed that `master` had failed on this.