### PR TITLE
Version bump curl-sys

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.25"
+version = "0.4.26"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"


### PR DESCRIPTION
I'd like to pull in https://github.com/alexcrichton/curl-rust/pull/283 downstream so that I can handle https://github.com/sagebind/isahc/issues/68. Master has everything needed now, I just need a new version published...