### PR TITLE
Define HTTP/3 constant

### DIFF
--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -602,6 +602,9 @@ pub const CURL_HTTP_VERSION_2TLS: c_int = 4;
 /// Please use HTTP 2 without HTTP/1.1 Upgrade
 /// (Added in CURL 7.49.0)
 pub const CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE: c_int = 5;
+/// Makes use of explicit HTTP/3 without fallback.
+/// (Added in CURL 7.66.0)
+pub const CURL_HTTP_VERSION_3: c_int = 30;
 
 // Note that the type here is wrong, it's just intended to just be an enum.
 pub const CURL_SSLVERSION_DEFAULT: CURLoption = 0;

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -461,6 +461,17 @@ pub enum HttpVersion {
     /// (Added in CURL 7.49.0)
     V2PriorKnowledge = curl_sys::CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE as isize,
 
+    /// Setting this value will make libcurl attempt to use HTTP/3 directly to
+    /// server given in the URL. Note that this cannot gracefully downgrade to
+    /// earlier HTTP version if the server doesn't support HTTP/3.
+    ///
+    /// For more reliably upgrading to HTTP/3, set the preferred version to
+    /// something lower and let the server announce its HTTP/3 support via
+    /// Alt-Svc:.
+    ///
+    /// (Added in CURL 7.66.0)
+    V3 = curl_sys::CURL_HTTP_VERSION_3 as isize,
+
     /// Hidden variant to indicate that this enum should not be matched on, it
     /// may grow over time.
     #[doc(hidden)]

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -70,6 +70,12 @@ fn main() {
                 _ => {}
             }
         }
+        if version < 66 {
+            match s {
+                "CURL_HTTP_VERSION_3" => return true,
+                _ => {}
+            }
+        }
         if version < 65 {
             match s {
                 "CURLVERSION_SIXTH" => return true,


### PR DESCRIPTION
HTTP/3 support in libcurl is still experimental at this point, but the constant for requesting it is stable. This just defines the constant and makes it available in the `curl` crate.