### PR TITLE
Pin nightly to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - build: x86_64-nightly
             os: ubuntu-latest
-            rust: nightly
+            # FIXME(kennytm/extprim#19) waiting for a publish to unpin
+            rust: nightly-2020-05-01
             docker: linux64
             target: x86_64-unknown-linux-gnu
           - build: i686


### PR DESCRIPTION
Waiting for upstream fixes, so let's unbreak our own CI to avoid
blocking on that.

Closes #337