### PR TITLE
Add unix_socket_path that exposes more Unix socket control

### DIFF
--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -165,6 +165,11 @@ impl Easy {
         self.inner.unix_socket(unix_domain_socket)
     }
 
+    /// Same as [`Easy2::unix_socket_path`](struct.Easy2.html#method.unix_socket_path)
+    pub fn unix_socket_path<P: AsRef<Path>>(&mut self, path: Option<P>) -> Result<(), Error> {
+        self.inner.unix_socket_path(path)
+    }
+
     // =========================================================================
     // Callback options
 

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -791,16 +791,43 @@ impl<H> Easy2<H> {
         self.setopt_long(curl_sys::CURLOPT_WILDCARDMATCH, m as c_long)
     }
 
-    /// Provides the unix domain socket which this handle will work with.
+    /// Provides the Unix domain socket which this handle will work with.
     ///
-    /// The string provided must be unix domain socket -encoded with the format:
+    /// The string provided must be a path to a Unix domain socket encoded with
+    /// the format:
     ///
     /// ```text
     /// /path/file.sock
     /// ```
+    ///
+    /// By default this option is not set and corresponds to
+    /// [`CURLOPT_UNIX_SOCKET_PATH`](https://curl.haxx.se/libcurl/c/CURLOPT_UNIX_SOCKET_PATH.html).
     pub fn unix_socket(&mut self, unix_domain_socket: &str) -> Result<(), Error> {
         let socket = CString::new(unix_domain_socket)?;
         self.setopt_str(curl_sys::CURLOPT_UNIX_SOCKET_PATH, &socket)
+    }
+
+    /// Provides the Unix domain socket which this handle will work with.
+    ///
+    /// The string provided must be a path to a Unix domain socket encoded with
+    /// the format:
+    ///
+    /// ```text
+    /// /path/file.sock
+    /// ```
+    ///
+    /// This function is an alternative to [`Easy2::unix_socket`] that supports
+    /// non-UTF-8 paths and also supports disabling Unix sockets by setting the
+    /// option to `None`.
+    ///
+    /// By default this option is not set and corresponds to
+    /// [`CURLOPT_UNIX_SOCKET_PATH`](https://curl.haxx.se/libcurl/c/CURLOPT_UNIX_SOCKET_PATH.html).
+    pub fn unix_socket_path<P: AsRef<Path>>(&mut self, path: Option<P>) -> Result<(), Error> {
+        if let Some(path) = path {
+            self.setopt_path(curl_sys::CURLOPT_UNIX_SOCKET_PATH, path.as_ref())
+        } else {
+            self.setopt_ptr(curl_sys::CURLOPT_UNIX_SOCKET_PATH, 0 as _)
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
The existing `unix_socket` method has some limitations in its design:

- You cannot unset a previously set path.
- You cannot set non-UTF-8 paths.

This adds a second method named `unix_socket_path` that instead takes an `Option<impl AsRef<Path>>` which more closely aligns with what libcurl accepts for this option. We could consider soft-deprecating `unix_socket`, but I left it alone for now.