### PR TITLE
Enable HAVE_GETSOCKNAME for bundled build

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -202,6 +202,7 @@ fn main() {
         .file("curl/lib/wildcard.c")
         .define("HAVE_GETADDRINFO", None)
         .define("HAVE_GETPEERNAME", None)
+        .define("HAVE_GETSOCKNAME", None)
         .warnings(false);
 
     if cfg!(feature = "protocol-ftp") {


### PR DESCRIPTION
Define `HAVE_GETSOCKNAME` for bundled curl-sys so that `Easy2::local_ip` and `Easy2::local_port` don't return blank values. We're already enabling `HAVE_GETPEERNAME` and your system probably has `getsockname` if it has `getpeername`.