### PR TITLE
Add support for zlib-ng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl"
-version = "0.4.31"
+version = "0.4.32"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT"
 repository = "https://github.com/alexcrichton/curl-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 
 [dependencies]
 libc = "0.2.42"
-curl-sys = { path = "curl-sys", version = "0.4.33", default-features = false }
+curl-sys = { path = "curl-sys", version = "0.4.35", default-features = false }
 socket2 = "0.3.7"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
@@ -47,6 +47,7 @@ static-curl = ["curl-sys/static-curl"]
 static-ssl = ["curl-sys/static-ssl"]
 force-system-lib-on-osx = ['curl-sys/force-system-lib-on-osx']
 protocol-ftp = ["curl-sys/protocol-ftp"]
+zlib-ng-compat = ["curl-sys/zlib-ng-compat", "static-curl"]
 
 [[test]]
 name = "atexit"

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.34+curl-7.71.1"
+version = "0.4.35+curl-7.71.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"
@@ -19,7 +19,7 @@ name = "curl_sys"
 path = "lib.rs"
 
 [dependencies]
-libz-sys = "1.0.18"
+libz-sys = { version = "1.0.18", default-features = false, features = ["libc"] }
 libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1.3" }
 
@@ -51,3 +51,4 @@ static-ssl = ["openssl-sys/vendored"]
 spnego = []
 force-system-lib-on-osx = []
 protocol-ftp = []
+zlib-ng-compat = ["libz-sys/zlib-ng", "static-curl"]


### PR DESCRIPTION
Upgrade to libz-sys 1.1.0. Add a feature zlib-ng-compat to build with
zlib-ng in zlib-compat mode. This requires building our own curl (as
system curl will link with another zlib), so make zlib-ng-compat require
static-curl.