### PR TITLE
Upgrade socket2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 [dependencies]
 libc = "0.2.42"
 curl-sys = { path = "curl-sys", version = "0.4.37", default-features = false }
-socket2 = "0.3.7"
+socket2 = "0.3.16"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]


### PR DESCRIPTION
Upgrades to a version not making invalid assumptions about the memory layout of `std::net::SocketAddr`.

Helps unblock https://github.com/rust-lang/rust/pull/78802. See that PR for more details.