### PR TITLE
Add environment variable to find GSSAPI

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -344,6 +344,10 @@ fn main() {
                 .file("curl/lib/curl_gssapi.c")
                 .file("curl/lib/socks_gssapi.c")
                 .file("curl/lib/vauth/spnego_gssapi.c");
+            if let Some(path) = env::var_os("GSSAPI_ROOT") {
+                let path = PathBuf::from(path);
+                cfg.include(path.join("include"));
+            }
 
             // Link against the MIT gssapi library. It might be desirable to add support for
             // choosing between MIT and Heimdal libraries in the future.


### PR DESCRIPTION
This change allows us to set the location for GSSAPI.
This would be useful on systems where the library is not found at the usual location [`/usr`](https://github.com/curl/curl/blob/master/configure.ac#L1417) or if the client wants to set it manually.
I tried to make the behaviour similar to [`DEP_NGHTTP2_ROOT`](https://github.com/theawless/curl-rust/blob/master/curl-sys/build.rs#L218).