### PR TITLE
Add experimental support for rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ name = "atexit"
 harness = false
 
 [[example]]
+name = "https"
+path = "examples/https.rs"
+
+[[example]]
 name = "ssl_proxy"
 path = "examples/ssl_proxy.rs"
 required-features = ["ssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ssl = ["openssl-sys", "openssl-probe", "curl-sys/ssl"] # OpenSSL/system TLS back
 mesalink = ["curl-sys/mesalink"] # MesaLink TLS backend
 http2 = ["curl-sys/http2"]
 spnego = ["curl-sys/spnego"]
+rustls = ["curl-sys/rustls"]
 static-curl = ["curl-sys/static-curl"]
 static-ssl = ["curl-sys/static-ssl"]
 force-system-lib-on-osx = ['curl-sys/force-system-lib-on-osx']

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ libcurl and the system-wide SSL library. Some of this behavior can be customized
 with various Cargo features:
 
 - `ssl`: Enable SSL/TLS support using the platform-default TLS backend. On Windows this is [Schannel], on macOS [Secure Transport], and [OpenSSL] (or equivalent) on all other platforms.  Enabled by default.
+- `rustls` Enable SSL/TLS support via [Rustls], a well-received alternative TLS backend written in Rust. Rustls is always statically linked. Disabled by default.
+
+  Note that Rustls support is experimental within Curl itself and may have significant bugs, so we don't offer any sort of stability guarantee with this feature.
 - `mesalink`: Enable SSL/TLS support via [MesaLink], an alternative TLS backend written in Rust based on [Rustls]. MesaLink is always statically linked. Disabled by default.
 - `http2`: Enable HTTP/2 support via libnghttp2. Disabled by default.
 - `static-curl`: Use a bundled libcurl version and statically link to it. Disabled by default.

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,6 +5,8 @@ set -ex
 cargo test --target $TARGET --no-run
 # First test with no extra protocols enabled.
 cargo test --target $TARGET --no-run --features static-curl
+# Then with rustls TLS backend.
+cargo test --target $TARGET --no-run --features rustls,static-curl
 # Then with all extra protocols enabled.
 cargo test --target $TARGET --no-run --features static-curl,protocol-ftp
 if [ -z "$NO_RUN" ]; then

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -24,9 +24,9 @@ libz-sys = { version = "1.0.18", default-features = false, features = ["libc"] }
 libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1.3" }
 
-[dependencies.crustls]
-git = "https://github.com/abetterinternet/crustls"
-rev = "31237742e77498b1dbf18c11035abc06839070dd"
+[dependencies.rustls-ffi]
+git = "https://github.com/rustls/rustls-ffi"
+tag = "v0.8.1"
 optional = true
 
 [dependencies.mesalink]
@@ -52,6 +52,7 @@ cc = "1.0"
 default = ["ssl"]
 ssl = ["openssl-sys"]
 http2 = ["libnghttp2-sys"]
+rustls = ["rustls-ffi"]
 static-curl = []
 static-ssl = ["openssl-sys/vendored"]
 spnego = []

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -24,16 +24,17 @@ libz-sys = { version = "1.0.18", default-features = false, features = ["libc"] }
 libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1.3" }
 
-[dependencies.rustls-ffi]
-git = "https://github.com/rustls/rustls-ffi"
-tag = "v0.8.1"
-optional = true
-
 [dependencies.mesalink]
 version = "1.1.0-cratesio"
 optional = true
 default-features = false
 features = ["client_apis", "error_strings", "tls13", "aesgcm", "chachapoly", "x25519", "ecdh", "ecdsa", "verifier"]
+
+[dependencies.rustls-ffi]
+git = "https://github.com/rustls/rustls-ffi"
+tag = "v0.8.2"
+optional = true
+features = ["no_log_capture"]
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 openssl-sys = { version = "0.9", optional = true }

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -31,8 +31,7 @@ default-features = false
 features = ["client_apis", "error_strings", "tls13", "aesgcm", "chachapoly", "x25519", "ecdh", "ecdsa", "verifier"]
 
 [dependencies.rustls-ffi]
-git = "https://github.com/rustls/rustls-ffi"
-tag = "v0.8.2"
+version = "0.8"
 optional = true
 features = ["no_log_capture"]
 

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -24,6 +24,11 @@ libz-sys = { version = "1.0.18", default-features = false, features = ["libc"] }
 libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1.3" }
 
+[dependencies.crustls]
+git = "https://github.com/abetterinternet/crustls"
+rev = "31237742e77498b1dbf18c11035abc06839070dd"
+optional = true
+
 [dependencies.mesalink]
 version = "1.1.0-cratesio"
 optional = true

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -261,6 +261,10 @@ fn main() {
         } else {
             cfg.define("HAVE_UNIX", None);
         }
+    } else if cfg!(feature = "rustls") {
+        cfg.define("USE_RUSTLS", None)
+            .file("curl/lib/vtls/rustls.c")
+            .include(env::var_os("DEP_CRUSTLS_INCLUDE").unwrap());
     } else if cfg!(feature = "ssl") {
         if windows {
             // For windows, spnego feature is auto on in case ssl feature is on.

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -264,7 +264,7 @@ fn main() {
     } else if cfg!(feature = "rustls") {
         cfg.define("USE_RUSTLS", None)
             .file("curl/lib/vtls/rustls.c")
-            .include(env::var_os("DEP_CRUSTLS_INCLUDE").unwrap());
+            .include(env::var_os("DEP_RUSTLS_FFI_INCLUDE").unwrap());
     } else if cfg!(feature = "ssl") {
         if windows {
             // For windows, spnego feature is auto on in case ssl feature is on.

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -2,8 +2,6 @@
 #![doc(html_root_url = "https://docs.rs/curl-sys/0.3")]
 
 // These `extern crate` are required for conditional linkages of curl.
-#[cfg(feature = "rustls")]
-extern crate crustls;
 #[cfg(link_libnghttp2)]
 extern crate libnghttp2_sys;
 #[cfg(link_libz)]
@@ -12,6 +10,8 @@ extern crate libz_sys;
 extern crate mesalink;
 #[cfg(link_openssl)]
 extern crate openssl_sys;
+#[cfg(feature = "rustls")]
+extern crate rustls_ffi;
 
 use libc::c_ulong;
 use libc::{c_char, c_double, c_int, c_long, c_short, c_uint, c_void, size_t, time_t};

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -2,10 +2,8 @@
 #![doc(html_root_url = "https://docs.rs/curl-sys/0.3")]
 
 // These `extern crate` are required for conditional linkages of curl.
-extern crate libc;
 #[cfg(feature = "rustls")]
 extern crate crustls;
-extern crate libc;
 #[cfg(link_libnghttp2)]
 extern crate libnghttp2_sys;
 #[cfg(link_libz)]

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -5,6 +5,7 @@
 extern crate libc;
 #[cfg(feature = "rustls")]
 extern crate crustls;
+extern crate libc;
 #[cfg(link_libnghttp2)]
 extern crate libnghttp2_sys;
 #[cfg(link_libz)]

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -2,6 +2,9 @@
 #![doc(html_root_url = "https://docs.rs/curl-sys/0.3")]
 
 // These `extern crate` are required for conditional linkages of curl.
+extern crate libc;
+#[cfg(feature = "rustls")]
+extern crate crustls;
 #[cfg(link_libnghttp2)]
 extern crate libnghttp2_sys;
 #[cfg(link_libz)]

--- a/examples/https.rs
+++ b/examples/https.rs
@@ -1,0 +1,23 @@
+//! Simple HTTPS GET
+//!
+//! This example is a Rust adaptation of the [C example of the same
+//! name](https://curl.se/libcurl/c/https.html).
+
+extern crate curl;
+
+use curl::easy::Easy;
+use std::io::{stdout, Write};
+
+fn main() -> Result<(), curl::Error> {
+    let mut curl = Easy::new();
+
+    curl.url("https://example.com/")?;
+    curl.write_function(|data| {
+        stdout().write_all(data).unwrap();
+        Ok(data.len())
+    })?;
+
+    curl.perform()?;
+
+    Ok(())
+}


### PR DESCRIPTION
This adds experimental support for using rustls as a TLS backend for curl. This is made possible by the upstream rustls support recently added to curl via [rustls-ffi](https://github.com/rustls/rustls-ffi).

- [x] ~Upstream rustls was recently merged in as an experimental feature and likely is buggy. Is it OK for us to publish curl-rust with a `rustls` feature, knowing that it is experimental and may have serious bugs?~ Rustls support has greatly improved since being introduced, and docs are sufficient warning that implementation may not be fully complete yet.
- [x] ~Will the [crustls](https://github.com/abetterinternet/crustls) wrapper be willing to officially support our unusual use-case? Alternatively we can maintain a fork that is published to Crates.io as `curl-crustls` or equivalent.~ The `rustls-ffi` bindings package is now published to Crates.io.
- [x] ~Is it even correct to use `package.links` for crates that expose `no_mangle` symbols but don't actually link to anything external?~ Yes, this is appropriate.
- [x] Check rustls builds in CI
- [x] Update to a released curl version with support for rustls-ffi 0.8+

See #341.