### PR TITLE
Fix debug formatting for Events struct

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1041,8 +1041,8 @@ impl fmt::Debug for Events {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Events")
             .field("input", &(self.bits & curl_sys::CURL_CSELECT_IN != 0))
-            .field("output", &(self.bits & curl_sys::CURL_CSELECT_IN != 0))
-            .field("error", &(self.bits & curl_sys::CURL_CSELECT_IN != 0))
+            .field("output", &(self.bits & curl_sys::CURL_CSELECT_OUT != 0))
+            .field("error", &(self.bits & curl_sys::CURL_CSELECT_ERR != 0))
             .finish()
     }
 }


### PR DESCRIPTION
Fix a copy and paste error that showed the value of the `input` flag of `Events` in place of the `output` and `error` flags in the debug formatting.