### PR TITLE
Fix TCP_NODELAY not defined for static builds on Unix

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -344,10 +344,6 @@ fn main() {
                 .define("HAVE_GETTIMEOFDAY", None);
         }
 
-        if target.contains("-linux-") {
-            cfg.define("HAVE_LINUX_TCP_H", None);
-        }
-
         if cfg!(feature = "spnego") {
             cfg.define("HAVE_GSSAPI", None)
                 .file("curl/lib/curl_gssapi.c")

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -238,11 +238,6 @@ fn main() {
             .file("curl/lib/vauth/vauth.c");
     }
 
-    if !windows {
-        cfg.define("USE_UNIX_SOCKETS", None)
-            .define("HAVE_SYS_UN_H", None);
-    }
-
     // Configure TLS backend. Since Cargo does not support mutually exclusive
     // features, make sure we only compile one vtls.
     if cfg!(feature = "mesalink") {
@@ -288,6 +283,7 @@ fn main() {
         }
     }
 
+    // Configure platform-specific details.
     if windows {
         cfg.define("WIN32", None)
             .define("USE_THREADS_WIN32", None)
@@ -301,15 +297,6 @@ fn main() {
             cfg.file("curl/lib/vauth/spnego_sspi.c");
         }
     } else {
-        if target.contains("-apple-") {
-            cfg.define("__APPLE__", None)
-                .define("macintosh", None)
-                .define("HAVE_MACH_ABSOLUTE_TIME", None);
-        } else {
-            cfg.define("HAVE_CLOCK_GETTIME_MONOTONIC", None)
-                .define("HAVE_GETTIMEOFDAY", None);
-        }
-
         cfg.define("RECV_TYPE_ARG1", "int")
             .define("HAVE_PTHREAD_H", None)
             .define("HAVE_ARPA_INET_H", None)
@@ -317,6 +304,7 @@ fn main() {
             .define("HAVE_FCNTL_H", None)
             .define("HAVE_NETDB_H", None)
             .define("HAVE_NETINET_IN_H", None)
+            .define("HAVE_NETINET_TCP_H", None)
             .define("HAVE_POLL_FINE", None)
             .define("HAVE_POLL_H", None)
             .define("HAVE_FCNTL_O_NONBLOCK", None)
@@ -330,7 +318,9 @@ fn main() {
             .define("HAVE_STERRROR_R", None)
             .define("HAVE_SOCKETPAIR", None)
             .define("HAVE_STRUCT_TIMEVAL", None)
+            .define("HAVE_SYS_UN_H", None)
             .define("USE_THREADS_POSIX", None)
+            .define("USE_UNIX_SOCKETS", None)
             .define("RECV_TYPE_ARG2", "void*")
             .define("RECV_TYPE_ARG3", "size_t")
             .define("RECV_TYPE_ARG4", "int")
@@ -344,6 +334,19 @@ fn main() {
             .define("SIZEOF_CURL_OFF_T", "8")
             .define("SIZEOF_INT", "4")
             .define("SIZEOF_SHORT", "2");
+
+        if target.contains("-apple-") {
+            cfg.define("__APPLE__", None)
+                .define("macintosh", None)
+                .define("HAVE_MACH_ABSOLUTE_TIME", None);
+        } else {
+            cfg.define("HAVE_CLOCK_GETTIME_MONOTONIC", None)
+                .define("HAVE_GETTIMEOFDAY", None);
+        }
+
+        if target.contains("-linux-") {
+            cfg.define("HAVE_LINUX_TCP_H", None);
+        }
 
         if cfg!(feature = "spnego") {
             cfg.define("HAVE_GSSAPI", None)


### PR DESCRIPTION
The `TCP_NODELAY` macro/constant was not being defined during compilation for the bundled libcurl build on Unix systems because `netinet/tcp.h` was not being included. It is difficult to verify that this is working properly without a debugger or strace. I've confirmed this fix on Linux and macOS.

Also rearrange some of the defines to help keep the build script somewhat organized.

Fixes #379.