### PR TITLE
Disable compiling with poll() on macOS

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -300,7 +300,6 @@ fn main() {
             .define("HAVE_NETDB_H", None)
             .define("HAVE_NETINET_IN_H", None)
             .define("HAVE_NETINET_TCP_H", None)
-            .define("HAVE_POLL_FINE", None)
             .define("HAVE_POLL_H", None)
             .define("HAVE_FCNTL_O_NONBLOCK", None)
             .define("HAVE_SYS_SELECT_H", None)
@@ -336,7 +335,11 @@ fn main() {
                 .define("HAVE_MACH_ABSOLUTE_TIME", None);
         } else {
             cfg.define("HAVE_CLOCK_GETTIME_MONOTONIC", None)
-                .define("HAVE_GETTIMEOFDAY", None);
+                .define("HAVE_GETTIMEOFDAY", None)
+                // poll() on various versions of macOS are janky, so only use it
+                // on non-macOS unix-likes. This matches the official default
+                // build configuration as well.
+                .define("HAVE_POLL_FINE", None);
         }
 
         if cfg!(feature = "spnego") {


### PR DESCRIPTION
I've noticed recently that when using the bundled curl version on macOS, very occasionally curl will get "stuck" in the TCP connection phase when using the multi interface. Apparently this is caused by the `poll()` implementation not behaving quite as the POSIX standard says it should on some macOS versions. (Curl uses `poll()`/`select()` to check if a socket has finished connecting without blocking, even if you are not using those functions to poll read/write readiness.)

This originally was a problem just for macOS 10.12, but after a recent update it seems like this regression might have come back in 10.15. It is more reliable to just disable `poll()` completely on macOS, which the official build configuration does here: https://github.com/curl/curl/blob/1e19eceb50d6d8b9c9b37e2f8e1259b2f311c82a/m4/curl-functions.m4#L4999-L5010

See also https://github.com/curl/curl/issues/1057 when this was originally reported way back in the day.