### PR TITLE
Update ctest to ctest2

### DIFF
--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -11,5 +11,5 @@ curl-sys = { path = "../curl-sys" }
 libc = "0.2"
 
 [build-dependencies]
-ctest = { git = 'https://github.com/alexcrichton/ctest', branch = 'use-maybe-unini' }
+ctest2 = "0.4"
 cc = "1.0"

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::str;
 
 fn main() {
-    let mut cfg = ctest::TestGenerator::new();
+    let mut cfg = ctest2::TestGenerator::new();
 
     let mut build = cc::Build::new();
     build.file("version_detect.c");


### PR DESCRIPTION
This swaps out ctest with a fork which has been updated to be able to compile on newer rustc versions. This fixes the failing tests on nightly in CI recently introduced.

Long-term we should consider moving off of ctest, but that's a larger effort with more unknowns.