### PR TITLE
Add support for aws-sigv4 authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,8 @@ required-features = ["ssl"]
 name = "ssl_cert_blob"
 path = "examples/ssl_cert_blob.rs"
 required-features = ["ssl"]
+
+[[example]]
+name = "aws_sigv4"
+path = "examples/aws_sigv4.rs"
+required-features = ["static-curl", "ssl"]

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -109,7 +109,6 @@ fn main() {
         .include("curl/lib")
         .include("curl/include")
         .define("BUILDING_LIBCURL", None)
-        .define("CURL_DISABLE_CRYPTO_AUTH", None)
         .define("CURL_DISABLE_DICT", None)
         .define("CURL_DISABLE_GOPHER", None)
         .define("CURL_DISABLE_IMAP", None)
@@ -127,6 +126,7 @@ fn main() {
         .define("HAVE_ASSERT_H", None)
         .define("OS", "\"unknown\"") // TODO
         .define("HAVE_ZLIB_H", None)
+        .define("HAVE_LONGLONG", None)
         .define("HAVE_LIBZ", None)
         .define("HAVE_BOOL_T", None)
         .define("HAVE_STDBOOL_H", None)
@@ -154,6 +154,7 @@ fn main() {
         .file("curl/lib/getenv.c")
         .file("curl/lib/getinfo.c")
         .file("curl/lib/hash.c")
+        .file("curl/lib/hmac.c")
         .file("curl/lib/hostasyn.c")
         .file("curl/lib/hostcheck.c")
         .file("curl/lib/hostip.c")
@@ -161,12 +162,15 @@ fn main() {
         .file("curl/lib/hsts.c")
         .file("curl/lib/http.c")
         .file("curl/lib/http2.c")
+        .file("curl/lib/http_aws_sigv4.c")
         .file("curl/lib/http_chunks.c")
+        .file("curl/lib/http_digest.c")
         .file("curl/lib/http_proxy.c")
         .file("curl/lib/if2ip.c")
         .file("curl/lib/inet_ntop.c")
         .file("curl/lib/inet_pton.c")
         .file("curl/lib/llist.c")
+        .file("curl/lib/md5.c")
         .file("curl/lib/mime.c")
         .file("curl/lib/mprintf.c")
         .file("curl/lib/mqtt.c")
@@ -180,6 +184,7 @@ fn main() {
         .file("curl/lib/select.c")
         .file("curl/lib/sendf.c")
         .file("curl/lib/setopt.c")
+        .file("curl/lib/sha256.c")
         .file("curl/lib/share.c")
         .file("curl/lib/slist.c")
         .file("curl/lib/socks.c")
@@ -196,6 +201,7 @@ fn main() {
         .file("curl/lib/url.c")
         .file("curl/lib/urlapi.c")
         .file("curl/lib/version.c")
+        .file("curl/lib/vauth/digest.c")
         .file("curl/lib/vtls/keylog.c")
         .file("curl/lib/vtls/vtls.c")
         .file("curl/lib/warnless.c")
@@ -253,11 +259,16 @@ fn main() {
         }
     } else if cfg!(feature = "ssl") {
         if windows {
+            // For windows, spnego feature is auto on in case ssl feature is on.
+            // Please see definition of USE_SPNEGO in curl_setup.h for more info.
             cfg.define("USE_WINDOWS_SSPI", None)
                 .define("USE_SCHANNEL", None)
+                .file("curl/lib/http_negotiate.c")
                 .file("curl/lib/x509asn1.c")
                 .file("curl/lib/curl_sspi.c")
                 .file("curl/lib/socks_sspi.c")
+                .file("curl/lib/vauth/spnego_sspi.c")
+                .file("curl/lib/vauth/vauth.c")
                 .file("curl/lib/vtls/schannel.c")
                 .file("curl/lib/vtls/schannel_verify.c");
         } else if target.contains("-apple-") {
@@ -287,8 +298,10 @@ fn main() {
             .define("USE_THREADS_WIN32", None)
             .define("HAVE_IOCTLSOCKET_FIONBIO", None)
             .define("USE_WINSOCK", None)
+            .file("curl/lib/bufref.c")
             .file("curl/lib/system_win32.c")
             .file("curl/lib/version_win32.c")
+            .file("curl/lib/vauth/digest_sspi.c")
             .file("curl/lib/curl_multibyte.c");
 
         if cfg!(feature = "spnego") {

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -310,6 +310,7 @@ pub const CURLAUTH_GSSNEGOTIATE: c_ulong = 1 << 2;
 pub const CURLAUTH_NTLM: c_ulong = 1 << 3;
 pub const CURLAUTH_DIGEST_IE: c_ulong = 1 << 4;
 pub const CURLAUTH_NTLM_WB: c_ulong = 1 << 5;
+pub const CURLAUTH_AWS_SIGV4: c_ulong = 1 << 7;
 // pub const CURLAUTH_ONLY: c_ulong = 1 << 31;
 pub const CURLAUTH_ANY: c_ulong = !CURLAUTH_DIGEST_IE;
 pub const CURLAUTH_ANYSAFE: c_ulong = !(CURLAUTH_BASIC | CURLAUTH_DIGEST_IE);
@@ -601,6 +602,8 @@ pub const CURLOPT_SSLKEY_BLOB: CURLoption = CURLOPTTYPE_BLOB + 292;
 pub const CURLOPT_PROXY_SSLCERT_BLOB: CURLoption = CURLOPTTYPE_BLOB + 293;
 pub const CURLOPT_PROXY_SSLKEY_BLOB: CURLoption = CURLOPTTYPE_BLOB + 294;
 pub const CURLOPT_ISSUERCERT_BLOB: CURLoption = CURLOPTTYPE_BLOB + 295;
+
+pub const CURLOPT_AWS_SIGV4: CURLoption = CURLOPTTYPE_OBJECTPOINT + 305;
 
 pub const CURL_IPRESOLVE_WHATEVER: c_int = 0;
 pub const CURL_IPRESOLVE_V4: c_int = 1;

--- a/examples/aws_sigv4.rs
+++ b/examples/aws_sigv4.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+
+use curl::easy::Easy;
+
+fn main() -> Result<()> {
+    let mut handle = Easy::new();
+    handle.verbose(true)?;
+    handle.url("https://ec2.us-east-1.amazonaws.com/?Action=DescribeRegions&Version=2013-10-15")?;
+    handle.aws_sigv4("aws:amz")?;
+    handle.username("myAccessKeyId")?;
+    handle.password("mySecretAccessKey")?;
+    handle.perform()?;
+    Ok(())
+}

--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -696,6 +696,11 @@ impl Easy {
         self.inner.http_auth(auth)
     }
 
+    /// Same as [`Easy2::aws_sigv4`](struct.Easy2.html#method.aws_sigv4)
+    pub fn aws_sigv4(&mut self, param: &str) -> Result<(), Error> {
+        self.inner.aws_sigv4(param)
+    }
+
     /// Same as [`Easy2::proxy_username`](struct.Easy2.html#method.proxy_username)
     pub fn proxy_username(&mut self, user: &str) -> Result<(), Error> {
         self.inner.proxy_username(user)

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -1153,6 +1153,33 @@ impl<H> Easy2<H> {
         self.setopt_long(curl_sys::CURLOPT_HTTPAUTH, auth.bits)
     }
 
+    /// Provides AWS V4 signature authentication on HTTP(S) header.
+    ///
+    /// `param` is used to create outgoing authentication headers.
+    /// Its format is `provider1[:provider2[:region[:service]]]`.
+    /// `provider1,\ provider2"` are used for generating auth parameters
+    /// such as "Algorithm", "date", "request type" and "signed headers".
+    /// `region` is the geographic area of a resources collection. It is
+    /// extracted from the host name specified in the URL if omitted.
+    /// `service` is a function provided by a cloud. It is extracted
+    /// from the host name specified in the URL if omitted.
+    ///
+    /// Example with "Test:Try", when curl will do the algorithm, it will
+    /// generate "TEST-HMAC-SHA256" for "Algorithm", "x-try-date" and
+    /// "X-Try-Date" for "date", "test4_request" for "request type", and
+    /// "SignedHeaders=content-type;host;x-try-date" for "signed headers".
+    /// If you use just "test", instead of "test:try", test will be use
+    /// for every strings generated.
+    ///
+    /// This is a special auth type that can't be combined with the others.
+    /// It will override the other auth types you might have set.
+    ///
+    /// By default this is not set and corresponds to `CURLOPT_AWS_SIGV4`.
+    pub fn aws_sigv4(&mut self, param: &str) -> Result<(), Error> {
+        let param = CString::new(param)?;
+        self.setopt_str(curl_sys::CURLOPT_AWS_SIGV4, &param)
+    }
+
     /// Configures the proxy username to pass as authentication for this
     /// connection.
     ///
@@ -3385,6 +3412,17 @@ impl Auth {
         self.flag(curl_sys::CURLAUTH_NTLM_WB, on)
     }
 
+    /// HTTP AWS V4 signature authentication.
+    ///
+    /// This is a special auth type that can't be combined with the others.
+    /// It will override the other auth types you might have set.
+    ///
+    /// Enabling this auth type is the same as using "aws:amz" as param in
+    /// [`Easy2::aws_sigv4`](struct.Easy2.html#method.aws_sigv4) method.
+    pub fn aws_sigv4(&mut self, on: bool) -> &mut Auth {
+        self.flag(curl_sys::CURLAUTH_AWS_SIGV4, on)
+    }
+
     fn flag(&mut self, bit: c_ulong, on: bool) -> &mut Auth {
         if on {
             self.bits |= bit as c_long;
@@ -3408,6 +3446,7 @@ impl fmt::Debug for Auth {
             )
             .field("ntlm", &(bits & curl_sys::CURLAUTH_NTLM != 0))
             .field("ntlm_wb", &(bits & curl_sys::CURLAUTH_NTLM_WB != 0))
+            .field("aws_sigv4", &(bits & curl_sys::CURLAUTH_AWS_SIGV4 != 0))
             .finish()
     }
 }

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -78,6 +78,8 @@ fn main() {
         }
         if version < 75 {
             match s {
+                "CURLAUTH_AWS_SIGV4" => return true,
+                "CURLOPT_AWS_SIGV4" => return true,
                 "CURLVERSION_NINTH" => return true,
                 _ => {}
             }


### PR DESCRIPTION
Used these platforms:
* Windows10 + MSVC 14.29
* macOS Big Sur + Apple clang 12.0
* Linux 5.4 + GCC 7.3

I wasn't sure what feature combinations to build curl-rust with to test properly.
So, I wrote [this script](https://github.com/theawless/curl-rust/commit/4d4fca5c54772d47e6376045adf56dc2226fc38c) which runs all of them (1024 combinations).
Would it be useful to add it in the CI somehow?

For macOS and Linux, all builds work fine.
For Windows, some of them are breaking, but they had been breaking before my changes. 
`mesalink` + `spnego` doesn't build together on Windows. Is this expected?

Closes https://github.com/alexcrichton/curl-rust/issues/392