### PR TITLE
Trigger rebuild if a curl source file has changed.

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-changed=curl");
     let host = env::var("HOST").unwrap();
     let target = env::var("TARGET").unwrap();
     let windows = target.contains("windows");


### PR DESCRIPTION
When doing local development on Linux, if any of the curl source files are changed, cargo will not trigger a rebuild. This is because pkg_config prints various rerun-if-env-changed values which prevents scanning for source file changes. This adds a basic rerun-if-changed to pick up any changes to the curl submodule.

The only downside to this is if the package is being built before initializing the submodule, [this code](https://github.com/alexcrichton/curl-rust/blob/8eb27f7c3427c6f730313f49aeeddf814c5b2bb1/curl-sys/build.rs#L43-L47) will initialize it, but with a timestamp after the build started.  This means the second cargo command will rebuild *again*, unfortunately.  I don't think there is any way to avoid this, and I think should be sufficiently rare not to matter.  CI here initializes the submodule before starting.
