### PR TITLE
Add vendored field to Version information.

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -64,6 +64,7 @@ fn main() {
     println!("cargo:root={}", dst.display());
     println!("cargo:include={}", include.display());
     println!("cargo:static=1");
+    println!("cargo:rustc-cfg=libcurl_vendored");
     fs::create_dir_all(include.join("curl")).unwrap();
 
     for header in [

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -1111,3 +1111,8 @@ extern "C" {
 pub fn rust_crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
+
+#[doc(hidden)]
+pub fn vendored() -> bool {
+    cfg!(libcurl_vendored)
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -51,6 +51,11 @@ impl Version {
         unsafe { (*self.inner).version_num as u32 }
     }
 
+    /// Returns true if this was built with the vendored version of libcurl.
+    pub fn vendored(&self) -> bool {
+        curl_sys::vendored()
+    }
+
     /// Returns a human readable string of the host libcurl is built for.
     ///
     /// This is discovered as part of the build environment.
@@ -389,6 +394,7 @@ impl fmt::Debug for Version {
         f.field("version", &self.version())
             .field("rust_crate_version", &env!("CARGO_PKG_VERSION"))
             .field("rust_sys_crate_version", &curl_sys::rust_crate_version())
+            .field("vendored", &self.vendored())
             .field("host", &self.host())
             .field("feature_ipv6", &self.feature_ipv6())
             .field("feature_ssl", &self.feature_ssl())


### PR DESCRIPTION
This adds whether or not libgit2 was built with the vendored version or not.

My use case is to expose this information in Cargo (per https://github.com/rust-lang/cargo/issues/6275).