### PR TITLE
Fix Clippy lints

### DIFF
--- a/examples/ssl_proxy.rs
+++ b/examples/ssl_proxy.rs
@@ -16,9 +16,9 @@ fn main() -> Result<()> {
 
     handle.proxy(proxy_url)?;
     handle.proxy_port(proxy_port)?;
-    handle.proxy_cainfo(&cainfo)?;
-    handle.proxy_sslcert(&sslcert)?;
-    handle.proxy_sslkey(&sslkey)?;
+    handle.proxy_cainfo(cainfo)?;
+    handle.proxy_sslcert(sslcert)?;
+    handle.proxy_sslkey(sslkey)?;
     println!("ssl proxy setup done");
 
     handle.perform()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,6 @@ use std::fmt;
 use std::io;
 use std::str;
 
-use curl_sys;
-
 /// An error returned from various "easy" operations.
 ///
 /// This structure wraps a `CURLcode`.

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,7 +2,6 @@ use std::ffi::CStr;
 use std::fmt;
 use std::str;
 
-use curl_sys;
 use libc::{c_char, c_int};
 
 /// Version information about libcurl and the capabilities that it supports.

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -14,8 +14,7 @@ fn main() {
     let version = str::from_utf8(&version).unwrap();
     let version = version
         .lines()
-        .filter(|l| !l.is_empty() && !l.starts_with("#"))
-        .next()
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
         .and_then(|s| s.parse::<u32>().ok())
         .unwrap_or(10000);
     println!("got version: {}", version);
@@ -39,7 +38,7 @@ fn main() {
         "CURL" | "CURLM" | "CURLSH" | "curl_version_info_data" => s.to_string(),
         "curl_khtype" | "curl_khstat" | "curl_khmatch" => format!("enum {}", s),
         s if is_struct => format!("struct {}", s),
-        "sockaddr" => format!("struct sockaddr"),
+        "sockaddr" => "struct sockaddr".to_string(),
         s => s.to_string(),
     });
     // cfg.fn_cname(|s, l| l.unwrap_or(s).to_string());

--- a/tests/easy.rs
+++ b/tests/easy.rs
@@ -22,7 +22,7 @@ mod server;
 fn handle() -> Easy {
     let mut e = Easy::new();
     t!(e.timeout(Duration::new(20, 0)));
-    return e;
+    e
 }
 
 fn sink(data: &[u8]) -> Result<usize, WriteError> {

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -150,10 +150,8 @@ fn upload_lots() {
     while running {
         let n = t!(poll.poll(&mut events, cur_timeout));
 
-        if n == 0 {
-            if t!(m.timeout()) == 0 {
-                running = false;
-            }
+        if n == 0 && t!(m.timeout()) == 0 {
+            running = false;
         }
 
         for event in events.iter() {
@@ -167,10 +165,10 @@ fn upload_lots() {
                         } else {
                             let mut e = mio::Ready::empty();
                             if events.input() {
-                                e = e | mio::Ready::readable();
+                                e |= mio::Ready::readable();
                             }
                             if events.output() {
-                                e = e | mio::Ready::writable();
+                                e |= mio::Ready::writable();
                             }
                             if token == 0 {
                                 let token = next_token;

--- a/tests/post.rs
+++ b/tests/post.rs
@@ -20,7 +20,7 @@ fn handle() -> Easy {
     let mut list = List::new();
     t!(list.append("Expect:"));
     t!(e.http_headers(list));
-    return e;
+    e
 }
 
 #[test]

--- a/tests/server/mod.rs
+++ b/tests/server/mod.rs
@@ -31,7 +31,7 @@ fn run(stream: impl Read + Write, rx: &Receiver<Message>) {
             Message::Read(ref expected) => {
                 let mut expected = &expected[..];
                 let mut expected_headers = HashSet::new();
-                while let Some(i) = expected.find("\n") {
+                while let Some(i) = expected.find('\n') {
                     let line = &expected[..i + 1];
                     expected = &expected[i + 1..];
                     expected_headers.insert(line);
@@ -41,11 +41,11 @@ fn run(stream: impl Read + Write, rx: &Receiver<Message>) {
                 }
 
                 let mut expected_len = None;
-                while expected_headers.len() > 0 {
+                while !expected_headers.is_empty() {
                     let mut actual = String::new();
                     t!(socket.read_line(&mut actual));
                     if actual.starts_with("Content-Length") {
-                        let len = actual.split(": ").skip(1).next().unwrap();
+                        let len = actual.split(": ").nth(1).unwrap();
                         expected_len = len.trim().parse().ok();
                     }
                     // various versions of libcurl do different things here
@@ -84,13 +84,13 @@ fn run(stream: impl Read + Write, rx: &Receiver<Message>) {
                 while socket.limit() > 0 {
                     line.truncate(0);
                     t!(socket.read_line(&mut line));
-                    if line.len() == 0 {
+                    if line.is_empty() {
                         break;
                     }
-                    if expected.len() == 0 {
+                    if expected.is_empty() {
                         panic!("unexpected line: {:?}", line);
                     }
-                    let i = expected.find("\n").unwrap_or(expected.len() - 1);
+                    let i = expected.find('\n').unwrap_or(expected.len() - 1);
                     let expected_line = &expected[..i + 1];
                     expected = &expected[i + 1..];
                     if lines_match(expected_line, &line) {
@@ -103,7 +103,7 @@ fn run(stream: impl Read + Write, rx: &Receiver<Message>) {
                         expected_line, line
                     )
                 }
-                if expected.len() != 0 {
+                if !expected.is_empty() {
                     println!("didn't get expected data: {:?}", expected);
                 }
             }


### PR DESCRIPTION
This PR fixes various Clippy lints (and silences 5 of them), except for the one in `clang-sys`'s build script, which was fixed in #415.