### PR TITLE
Initialize openssl-probe env vars if curl requires init

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,8 @@ pub fn init() {
     extern "C" fn init_inner() {
         INIT.call_once(|| {
             #[cfg(need_openssl_init)]
+            openssl_probe::init_ssl_cert_env_vars();
+            #[cfg(need_openssl_init)]
             openssl_sys::init();
 
             unsafe {


### PR DESCRIPTION
This commit should fix an issue that showed up in rust-lang/cargo#10013
where curl's initialization was accidentally detecting that curl needed
an early initialization (due to sfackler/rust-openssl#1548). This early
initialization caused the later env-vars set by `openssl-probe` to not
actually be read since OpenSSL was already initialized. While not an
issue for `curl` I think it does pose an issue for other libraries like
libgit2 using OpenSSL.

The fix here is to initialize the env vars before OpenSSL, which should
have OpenSSL pick up the probe results.