### PR TITLE
Guarantee that curl_multi_remove_handle is called

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1027,9 +1027,9 @@ impl<H: fmt::Debug> fmt::Debug for Easy2Handle<H> {
     }
 }
 
-/// Guard that ensures that an easy handle is removed from a multi handle before
-/// the easy handle is dropped.
 impl DetachGuard {
+    /// Detach the referenced easy handle from its multi handle manually.
+    /// Subsequent calls to this method will have no effect.
     fn detach(&mut self) -> Result<(), MultiError> {
         if !self.easy.is_null() {
             unsafe {


### PR DESCRIPTION
Add a drop handler that guarantees that `curl_multi_remove_handle` is always called on easy handles added to a multi handle before the easy handle is dropped. Based on https://github.com/curl/curl/issues/7982, we should not be allowing users to drop a previously attached handle without first calling `curl_multi_remove_handle`. In curl versions between 7.77 and 7.80 this could cause a crash under certain circumstances. While this will likely be fixed in the next curl version, it is still recommended to not allow this, plus we must still handle this case for users who may not have updated to a patched libcurl.

I'm not totally happy with how this is implemented as it adds an `Arc::clone` call every time an easy handle is added to a multi handle, but I couldn't think of a better way of guaranteeing this behavior without breaking API changes.

I've verified that this does actually fix https://github.com/alexcrichton/curl-rust/issues/421 even without the upstream curl patch.

Fixes https://github.com/alexcrichton/curl-rust/issues/421.