### PR TITLE
Update to curl 7.81.0

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.51+curl-7.80.0"
+version = "0.4.51+curl-7.81.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"


### PR DESCRIPTION
I didn't see any urgent fixes in the release notes so this doesn't bump the `*-sys` crate version yet.