### PR TITLE
Never try to link with `/lib/darwin`

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -572,7 +572,9 @@ fn macos_link_search_path() -> Option<String> {
     for line in stdout.lines() {
         if line.contains("libraries: =") {
             let path = line.split('=').nth(1)?;
-            return Some(format!("{}/lib/darwin", path));
+            if !path.is_empty() {
+                return Some(format!("{}/lib/darwin", path));
+            }
         }
     }
 


### PR DESCRIPTION
`clang --print-search-dirs` may return `libraries: =` that leads to `/lib/darwin` which may leads to attempt to find `clang_rt.osx` inside this wired path and which fails the build.