### PR TITLE
Don't let pkg-config add system lib dirs to the search path

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -477,6 +477,7 @@ fn try_vcpkg() -> bool {
 
 fn try_pkg_config() -> bool {
     let mut cfg = pkg_config::Config::new();
+    cfg.print_system_libs(false);
     cfg.cargo_metadata(false);
     let lib = match cfg.probe("libcurl") {
         Ok(lib) => lib,


### PR DESCRIPTION
In its default configuration, pkg-config adds system-wide library
directories to the linker search path (rust-lang/pkg-config-rs#11).
This causes these directories to be searched before other paths added
by later crates or by `-Clink-arg` in rustflags. If a library is present in
the system-wide directory and a later build step wants to specifically
link against a different version of that library in another path, the linker
will choose the library from the first search directory it finds. If the linker
doesn't find a library in any of the specified search directories, it falls
back on system-wide paths, so we don't need to print the
path we found lubcurl in if it is in one of those system paths.

See rust-lang/libz-sys#50 for the same fix to libz that landed a while back.