### PR TITLE
Update curl to 7.83.0

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.53+curl-7.82.0"
+version = "0.4.54+curl-7.83.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -76,6 +76,7 @@ fn main() {
         "curlver.h",
         "easy.h",
         "options.h",
+        "header.h",
         "mprintf.h",
         "multi.h",
         "stdcheaders.h",
@@ -212,6 +213,7 @@ fn main() {
         .file("curl/lib/vtls/vtls.c")
         .file("curl/lib/warnless.c")
         .file("curl/lib/wildcard.c")
+        .file("curl/lib/timediff.c")
         .define("HAVE_GETADDRINFO", None)
         .define("HAVE_GETPEERNAME", None)
         .define("HAVE_GETSOCKNAME", None)


### PR DESCRIPTION
Release notes: https://curl.se/mail/lib-2022-04/0053.html

Note that this release fixes multiple just-announced CVEs:

- https://curl.se/docs/CVE-2022-22576.html
- https://curl.se/docs/CVE-2022-27774.html
- https://curl.se/docs/CVE-2022-27775.html
- https://curl.se/docs/CVE-2022-27776.html