### PR TITLE
Define 'CURL_CA_BUNDLE' with default values

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -316,7 +316,7 @@ fn main() {
                 "/etc/pki/tls/certs/ca-bundle.crt",
                 "/usr/share/ssl/certs/ca-bundle.crt",
                 "/usr/local/share/certs/ca-root-nss.crt",
-                "/etc/ssl/cert.pem"
+                "/etc/ssl/cert.pem",
             ]
             .iter();
 

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -300,13 +300,13 @@ fn main() {
         } else {
             cfg.define("USE_OPENSSL", None)
                 .file("curl/lib/vtls/openssl.c");
-            
+
             println!("cargo:rustc-cfg=link_openssl");
             if let Some(path) = env::var_os("DEP_OPENSSL_INCLUDE") {
                 cfg.include(path);
             }
         }
-        
+
         if !windows {
             // Inserting default certification bundle file for Unix(-like) systems
             // curl's generated configure file inspired
@@ -315,12 +315,13 @@ fn main() {
             /etc/pki/tls/certs/ca-bundle.crt\r\n
             /usr/share/ssl/certs/ca-bundle.crt\r\n
             /usr/local/share/certs/ca-root-nss.crt\r\n
-            /etc/ssl/cert.pem".lines();
-             
+            /etc/ssl/cert.pem"
+            .lines();
+
             for iter_bundle in default_ca_bundles {
                 let m_bundle = std::path::Path::new(iter_bundle);
                 if m_bundle.exists() {
-                    let ca_bundle = path.replace("path",m_bundle.to_str().unwrap());
+                    let ca_bundle = path.replace("path", m_bundle.to_str().unwrap());
                     cfg.define("CURL_CA_BUNDLE", ca_bundle.as_str());
                     break;
                 }

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -311,12 +311,14 @@ fn main() {
             // Inserting default certification bundle file for Unix(-like) systems
             // curl's generated configure file inspired
             let path = "\"path\"";
-            let default_ca_bundles = "/etc/ssl/certs/ca-certificates.crt\r\n
-            /etc/pki/tls/certs/ca-bundle.crt\r\n
-            /usr/share/ssl/certs/ca-bundle.crt\r\n
-            /usr/local/share/certs/ca-root-nss.crt\r\n
-            /etc/ssl/cert.pem"
-            .lines();
+            let default_ca_bundles = [
+                "/etc/ssl/certs/ca-certificates.crt",
+                "/etc/pki/tls/certs/ca-bundle.crt",
+                "/usr/share/ssl/certs/ca-bundle.crt",
+                "/usr/local/share/certs/ca-root-nss.crt",
+                "/etc/ssl/cert.pem"
+            ]
+            .iter();
 
             for iter_bundle in default_ca_bundles {
                 let m_bundle = std::path::Path::new(iter_bundle);


### PR DESCRIPTION
Inserting default certification bundle file to avoiding no certification info error for normal use 'static-curl' feature on Unix(-like) systems.