### PR TITLE
Update bundled curl to 7.83.1

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.54+curl-7.83.0"
+version = "0.4.55+curl-7.83.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"


### PR DESCRIPTION
This version contains patches for six new CVEs just published:

- [CVE-2022-27778: curl removes wrong file on error](https://curl.se/docs/CVE-2022-27778.html)
- [CVE-2022-27779: cookie for trailing dot TLD](https://curl.se/docs/CVE-2022-27779.html)
- [CVE-2022-27780: percent-encoded path separator in URL host](https://curl.se/docs/CVE-2022-27780.html)
- [CVE-2022-27781: CERTINFO never-ending busy-loop](https://curl.se/docs/CVE-2022-27781.html)
- [CVE-2022-27782: TLS and SSH connection too eager reuse](https://curl.se/docs/CVE-2022-27782.html)
- [CVE-2022-30115: HSTS bypass via trailing dot](https://curl.se/docs/CVE-2022-30115.html)