### PR TITLE
Don't assume compiler is system clang on macOS

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -551,7 +551,9 @@ fn curl_config_reports_http2() -> bool {
 }
 
 fn macos_link_search_path() -> Option<String> {
-    let output = Command::new("clang")
+    let output = cc::Build::new()
+        .get_compiler()
+        .to_command()
         .arg("--print-search-dirs")
         .output()
         .ok()?;


### PR DESCRIPTION
On older systems, it may be necessary to use custom compiler.
So respect whichever compiler user is using to build crate.