### PR TITLE
Update OpenSSL dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ socket2 = "0.4.0"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-openssl-sys = { version = "0.9.43", optional = true }
-openssl-probe = { version = "0.1.2", optional = true }
+openssl-sys = { version = "0.9.75", optional = true }
+openssl-probe = { version = "0.1.5", optional = true }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 schannel = "0.1.13"


### PR DESCRIPTION
Allows build to succeed on Ubuntu 22.04 -- current OpenSSL deps fail with this error (which appears fixed upstream):

```
  CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
  running: "gcc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-m64" "-I" "/usr/include" "-Wall" "-Wextra" "-E" "build/expando.c"
  cargo:warning=build/expando.c:4:24: error: pasting "RUST_VERSION_OPENSSL_" and "(" does not give a valid preprocessing token         cargo:warning=    4 | #define VERSION2(n, v) RUST_VERSION_##n##_##v                                                                  cargo:warning=      |                        ^~~~~~~~~~~~~                                                                           cargo:warning=build/expando.c:5:23: note: in expansion of macro ‘VERSION2’                                                           cargo:warning=    5 | #define VERSION(n, v) VERSION2(n, v)
  cargo:warning=      |                       ^~~~~~~~
  cargo:warning=build/expando.c:10:1: note: in expansion of macro ‘VERSION’                                                            cargo:warning=   10 | VERSION(OPENSSL, OPENSSL_VERSION_NUMBER)
  cargo:warning=      | ^~~~~~~                                                                                                        exit status: 1
```