### PR TITLE
Add support for HTTPS proxy feature (#464)

### DIFF
--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -907,6 +907,7 @@ pub const CURL_VERSION_TLSAUTH_SRP: c_int = 1 << 14;
 pub const CURL_VERSION_NTLM_WB: c_int = 1 << 15;
 pub const CURL_VERSION_HTTP2: c_int = 1 << 16;
 pub const CURL_VERSION_UNIX_SOCKETS: c_int = 1 << 19;
+pub const CURL_VERSION_HTTPS_PROXY: c_int = 1 << 21;
 pub const CURL_VERSION_BROTLI: c_int = 1 << 23;
 pub const CURL_VERSION_ALTSVC: c_int = 1 << 24;
 pub const CURL_VERSION_HTTP3: c_int = 1 << 25;

--- a/src/version.rs
+++ b/src/version.rs
@@ -140,6 +140,11 @@ impl Version {
         self.flag(curl_sys::CURL_VERSION_UNIX_SOCKETS)
     }
 
+    /// Returns whether libcurl was built with support for HTTPS proxy.
+    pub fn feature_https_proxy(&self) -> bool {
+        self.flag(curl_sys::CURL_VERSION_HTTPS_PROXY)
+    }
+
     /// Returns whether libcurl was built with support for HTTP2.
     pub fn feature_http2(&self) -> bool {
         self.flag(curl_sys::CURL_VERSION_HTTP2)
@@ -413,6 +418,7 @@ impl fmt::Debug for Version {
                 "feature_unix_domain_socket",
                 &self.feature_unix_domain_socket(),
             )
+            .field("feature_https_proxy", &self.feature_https_proxy())
             .field("feature_altsvc", &self.feature_altsvc())
             .field("feature_zstd", &self.feature_zstd())
             .field("feature_unicode", &self.feature_unicode())

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -190,7 +190,8 @@ fn main() {
                 | "CURLOPT_PROXY_SSLCERTTYPE"
                 | "CURLOPT_PROXY_SSLKEY"
                 | "CURLOPT_PROXY_SSLKEYTYPE"
-                | "CURLOPT_PROXY_SSLVERSION" => return true,
+                | "CURLOPT_PROXY_SSLVERSION"
+                | "CURL_VERSION_HTTPS_PROXY" => return true,
                 _ => {}
             }
         }


### PR DESCRIPTION
Following #464 this PR exposes the flag HTTP_proxy (introduced in curl 7.52.0)