### PR TITLE
Update to 7.86.0

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.57+curl-7.85.0"
+version = "0.4.58+curl-7.86.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -83,6 +83,7 @@ fn main() {
         "system.h",
         "urlapi.h",
         "typecheck-gcc.h",
+        "websockets.h",
     ]
     .iter()
     {
@@ -145,12 +146,10 @@ fn main() {
         .file("curl/lib/content_encoding.c")
         .file("curl/lib/cookie.c")
         .file("curl/lib/curl_addrinfo.c")
-        .file("curl/lib/curl_ctype.c")
         .file("curl/lib/curl_get_line.c")
         .file("curl/lib/curl_memrchr.c")
         .file("curl/lib/curl_range.c")
         .file("curl/lib/curl_threads.c")
-        .file("curl/lib/dotdot.c")
         .file("curl/lib/doh.c")
         .file("curl/lib/dynbuf.c")
         .file("curl/lib/easy.c")
@@ -184,6 +183,7 @@ fn main() {
         .file("curl/lib/multi.c")
         .file("curl/lib/netrc.c")
         .file("curl/lib/nonblock.c")
+        .file("curl/lib/noproxy.c")
         .file("curl/lib/parsedate.c")
         .file("curl/lib/progress.c")
         .file("curl/lib/rand.c")


### PR DESCRIPTION
This updates to curl 7.86.0

This includes the fix that was causing issues with http2/tls 1.3/Windows 11 that caused the last release to be yanked. I have tested on Windows 11 and it seems to be working now.

Changelog: https://curl.se/changes.html#7_86_0

There are 4 CVE fixes in this release:

CVE-2022-42916: HSTS bypass via IDN
CVE-2022-42915: HTTP proxy double-free
CVE-2022-35260: .netrc parser out-of-bounds access
CVE-2022-32221: POST following PUT confusion

This release also adds support for websockets. However, I did not add any explicit support for that, though.
