### PR TITLE
Fix build error with clang

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 
 [dependencies]
 libc = "0.2.42"
-curl-sys = { path = "curl-sys", version = "0.4.56", default-features = false }
+curl-sys = { path = "curl-sys", version = "0.4.59", default-features = false }
 socket2 = "0.4.0"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.58+curl-7.86.0"
+version = "0.4.59+curl-7.86.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -358,6 +358,7 @@ fn main() {
             .define("HAVE_FCNTL_O_NONBLOCK", None)
             .define("HAVE_SYS_SELECT_H", None)
             .define("HAVE_SYS_STAT_H", None)
+            .define("HAVE_SYS_TIME_H", None)
             .define("HAVE_UNISTD_H", None)
             .define("HAVE_RECV", None)
             .define("HAVE_SELECT", None)


### PR DESCRIPTION
Due to some include files being rearranged in more recent versions of curl, the `sys/time.h` header was no longer being included for `timeval.c`, which was causing the error:

```
  cargo:warning=curl/lib/timeval.c:106:11: error: call to undeclared function 'gettimeofday'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  cargo:warning=    (void)gettimeofday(&now, NULL);
  cargo:warning=          ^
  cargo:warning=1 error generated.
```

This fixes it by setting HAVE_SYS_TIME_H which would normally be set by the configure script.

I don't actually know why gcc treats this as a warning, and clang treats it as an error.

Details:
`curl_setup.h` used to include `curl.h` which always [imports `sys/time.h`](https://github.com/curl/curl/blob/3390ef0af08bae327ff881ad8051623cbaa2d0f5/include/curl/curl.h#L87-L89). However, https://github.com/curl/curl/commit/e5839f4ee706054d3a9bb7430e0eac061d78e35a removed the `curl.h` import. The only way `sys/time.h` gets imported otherwise is in [`curl_setup_once.h`](https://github.com/curl/curl/blob/3390ef0af08bae327ff881ad8051623cbaa2d0f5/lib/curl_setup_once.h#L58-L60), but that is conditional on HAVE_SYS_TIME_H.
