### PR TITLE
Update libcurl to 7.88.1

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.59+curl-7.86.0"
+version = "0.4.60+curl-7.88.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -108,7 +108,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "7.61.1"),
+            .replace("@CURLVERSION@", "7.88.1"),
     )
     .unwrap();
 
@@ -141,12 +141,16 @@ fn main() {
         .file("curl/lib/altsvc.c")
         .file("curl/lib/base64.c")
         .file("curl/lib/bufref.c")
+        .file("curl/lib/cfilters.c")
+        .file("curl/lib/cf-http.c")
+        .file("curl/lib/cf-socket.c")
         .file("curl/lib/conncache.c")
         .file("curl/lib/connect.c")
         .file("curl/lib/content_encoding.c")
         .file("curl/lib/cookie.c")
         .file("curl/lib/curl_addrinfo.c")
         .file("curl/lib/curl_get_line.c")
+        .file("curl/lib/curl_log.c")
         .file("curl/lib/curl_memrchr.c")
         .file("curl/lib/curl_range.c")
         .file("curl/lib/curl_threads.c")
@@ -172,6 +176,7 @@ fn main() {
         .file("curl/lib/http_chunks.c")
         .file("curl/lib/http_digest.c")
         .file("curl/lib/http_proxy.c")
+        .file("curl/lib/idn.c")
         .file("curl/lib/if2ip.c")
         .file("curl/lib/inet_ntop.c")
         .file("curl/lib/inet_pton.c")
@@ -210,6 +215,10 @@ fn main() {
         .file("curl/lib/version.c")
         .file("curl/lib/vauth/digest.c")
         .file("curl/lib/vauth/vauth.c")
+        .file("curl/lib/vquic/curl_msh3.c")
+        .file("curl/lib/vquic/curl_ngtcp2.c")
+        .file("curl/lib/vquic/curl_quiche.c")
+        .file("curl/lib/vquic/vquic.c")
         .file("curl/lib/vtls/hostcheck.c")
         .file("curl/lib/vtls/keylog.c")
         .file("curl/lib/vtls/vtls.c")
@@ -386,7 +395,6 @@ fn main() {
 
         if target.contains("-apple-") {
             cfg.define("__APPLE__", None)
-                .define("macintosh", None)
                 .define("HAVE_MACH_ABSOLUTE_TIME", None);
         } else {
             cfg.define("HAVE_CLOCK_GETTIME_MONOTONIC", None)

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -870,7 +870,8 @@ pub const CURLVERSION_SEVENTH: CURLversion = 6;
 pub const CURLVERSION_EIGHTH: CURLversion = 7;
 pub const CURLVERSION_NINTH: CURLversion = 8;
 pub const CURLVERSION_TENTH: CURLversion = 9;
-pub const CURLVERSION_NOW: CURLversion = CURLVERSION_TENTH;
+pub const CURLVERSION_ELEVENTH: CURLversion = 10;
+pub const CURLVERSION_NOW: CURLversion = CURLVERSION_ELEVENTH;
 
 #[repr(C)]
 pub struct curl_version_info_data {
@@ -899,6 +900,7 @@ pub struct curl_version_info_data {
     pub zstd_version: *const c_char,
     pub hyper_version: *const c_char,
     pub gsasl_version: *const c_char,
+    pub feature_names: *const *const c_char,
 }
 
 pub const CURL_VERSION_IPV6: c_int = 1 << 0;

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -52,7 +52,7 @@ fn main() {
                 _ => {}
             }
         }
-        if version < 70 {
+        if version < 87 {
             match s {
                 "curl_version_info_data" => return true,
                 _ => {}
@@ -64,12 +64,17 @@ fn main() {
 
     // Version symbols are extracted from https://curl.se/libcurl/c/symbols-in-versions.html
     cfg.skip_const(move |s| {
+        if version < 87 {
+            match s {
+                "CURLVERSION_ELEVENTH" | "CURLVERSION_NOW" => return true,
+                _ => {}
+            }
+        }
         if version < 77 {
             match s {
                 "CURLVERSION_TENTH"
                 | "CURLOPT_CAINFO_BLOB"
                 | "CURLOPT_PROXY_CAINFO_BLOB"
-                | "CURLVERSION_NOW"
                 | "CURL_VERSION_ALTSVC"
                 | "CURL_VERSION_ZSTD"
                 | "CURL_VERSION_UNICODE"


### PR DESCRIPTION
Update libcurl from 7.86 to 7.88.1
Changelog: https://curl.se/changes.html

I haven't really looked at the quic/http3 support, or added any new bindings.
