### PR TITLE
Update socket2 dependency to the 0.5.x version (previously 0.4.x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 [dependencies]
 libc = "0.2.42"
 curl-sys = { path = "curl-sys", version = "0.4.59", default-features = false }
-socket2 = "0.4.0"
+socket2 = "0.5.0"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]


### PR DESCRIPTION
Socket2 0.4.x is no longer in active development. Passes tests on x86_64-unknown-linux and x86_64-unknown-haiku.