### PR TITLE
Use CURLOPT_TIMEOUT if timeout too big

### DIFF
--- a/tests/easy.rs
+++ b/tests/easy.rs
@@ -1000,3 +1000,33 @@ fn test_connect_timeout() {
             .unwrap()
     );
 }
+
+#[test]
+fn test_timeout() {
+    use curl::easy::Handler;
+    struct Collector(Vec<u8>);
+
+    impl Handler for Collector {
+        fn write(&mut self, data: &[u8]) -> Result<usize, WriteError> {
+            self.0.extend_from_slice(data);
+            Ok(data.len())
+        }
+    }
+    let mut easy2 = Easy2::new(Collector(Vec::new()));
+
+    // Overflow value test must return an Error
+    assert_eq!(
+        Error::new(curl_sys::CURLE_BAD_FUNCTION_ARGUMENT),
+        easy2
+            .timeout(Duration::from_secs(std::u64::MAX))
+            .unwrap_err()
+    );
+
+    // Valid value
+    assert_eq!(
+        (),
+        easy2
+            .timeout(Duration::from_millis(i32::MAX as u64))
+            .unwrap()
+    );
+}


### PR DESCRIPTION
i32 has a max of 2147483647, if the timeout duration is too big, it causes an overflow.