### PR TITLE
curl-sys: remove Haiku cross-compilation workaround

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -5,7 +5,6 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=curl");
-    let host = env::var("HOST").unwrap();
     let target = env::var("TARGET").unwrap();
     let windows = target.contains("windows");
 
@@ -17,13 +16,6 @@ fn main() {
     // usage of the system library to ensure that we're always building an
     // ABI-compatible Cargo.
     if cfg!(feature = "force-system-lib-on-osx") && target.contains("apple") {
-        return println!("cargo:rustc-flags=-l curl");
-    }
-
-    // When cross-compiling for Haiku, use the system's default supplied
-    // libcurl (it supports http2). This is in the case where rustc and
-    // cargo are built for Haiku, which is done from a Linux host.
-    if host != target && target.contains("haiku") {
         return println!("cargo:rustc-flags=-l curl");
     }
 


### PR DESCRIPTION
Previously, there were issues cross-compiling the curl library from source on the Haiku platform. That meant that a workaround was added to `build.rs` to always link to the shared library in that case. When testing for the current build, this workaround is no longer necessary, as cross-compiling the curl-sys crate works as expected.

This removes the workaround for this scenario, as it can now use the standard behavior.