### PR TITLE
Fix Multi::messages() signature

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -463,14 +463,14 @@ impl Multi {
     /// individual transfers. Messages may include informationals such as an
     /// error code from the transfer or just the fact that a transfer is
     /// completed. More details on these should be written down as well.
-    pub fn messages<F>(&self, mut f: F)
+    pub fn messages<'s, F>(&'s self, mut f: F)
     where
-        F: FnMut(Message),
+        F: FnMut(Message<'s>),
     {
         self._messages(&mut f)
     }
 
-    fn _messages(&self, f: &mut dyn FnMut(Message)) {
+    fn _messages<'s>(&'s self, f: &mut dyn FnMut(Message<'s>)) {
         let mut queue = 0;
         unsafe {
             loop {


### PR DESCRIPTION
The current
```rust
pub fn messages<F>(&self, mut f: F)
where
    F: FnMut(Message),
{
    self._messages(&mut f)
}

fn _messages(&self, f: &mut dyn FnMut(Message)) {
    let mut queue = 0;
    unsafe {
        loop {
            let ptr = curl_sys::curl_multi_info_read(self.raw.handle, &mut queue);
            if ptr.is_null() {
                break;
            }
            f(Message { ptr, _multi: self })
        }
    }
}
```
one meant that
```rust
let mut errors = vec![];
sucker.messages(|m| errors.push(m));
```
was illegal because
```
error[E0521]: borrowed data escapes outside of closure
    --> src\ops\mod.rs:1163:33
     |
1162 |             let mut errors = vec![];
     |                 ---------- `errors` declared here, outside of the closure body
1163 |             sucker.messages(|m| errors.push(m));
     |                              -  ^^^^^^^^^^^^^^ `m` escapes the closure body here
     |                              |
     |                              `m` is a reference that is only valid in the closure body
```

If it's not obvious at first glance, this is because `Message` is actually `Message<'multi>`, and the inferred lifetime was, expectedly, matching the `&mut self` of the `FnMut` (or close enough).

Instead, spec `messages<'s>(&'s self)` with `FnMut(Message<'s>)`, which fixes the above snippet by binding the `'multi` to the `Multi`.