### PR TITLE
Update curl to 8.1.0

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.61+curl-8.0.1"
+version = "0.4.62+curl-8.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -100,7 +100,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "8.0.1"),
+            .replace("@CURLVERSION@", "8.1.0"),
     )
     .unwrap();
 
@@ -132,8 +132,11 @@ fn main() {
         .file("curl/lib/asyn-thread.c")
         .file("curl/lib/altsvc.c")
         .file("curl/lib/base64.c")
+        .file("curl/lib/bufq.c")
         .file("curl/lib/bufref.c")
         .file("curl/lib/cfilters.c")
+        .file("curl/lib/cf-h1-proxy.c")
+        .file("curl/lib/cf-haproxy.c")
         .file("curl/lib/cf-https-connect.c")
         .file("curl/lib/cf-socket.c")
         .file("curl/lib/conncache.c")
@@ -148,6 +151,7 @@ fn main() {
         .file("curl/lib/curl_threads.c")
         .file("curl/lib/doh.c")
         .file("curl/lib/dynbuf.c")
+        .file("curl/lib/dynhds.c")
         .file("curl/lib/easy.c")
         .file("curl/lib/escape.c")
         .file("curl/lib/file.c")
@@ -164,6 +168,7 @@ fn main() {
         .file("curl/lib/hostip6.c")
         .file("curl/lib/hsts.c")
         .file("curl/lib/http.c")
+        .file("curl/lib/http1.c")
         .file("curl/lib/http_aws_sigv4.c")
         .file("curl/lib/http_chunks.c")
         .file("curl/lib/http_digest.c")
@@ -247,7 +252,7 @@ fn main() {
     if cfg!(feature = "http2") {
         cfg.define("USE_NGHTTP2", None)
             .define("NGHTTP2_STATICLIB", None)
-            .file("curl/lib/h2h3.c")
+            .file("curl/lib/cf-h2-proxy.c")
             .file("curl/lib/http2.c");
 
         println!("cargo:rustc-cfg=link_libnghttp2");


### PR DESCRIPTION
curl 8.0.1 is vulnerable to CVE-2023-{28319..28322}, see https://curl.se/docs/security.html