### PR TITLE
Update curl to 8.1.2

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.62+curl-8.1.0"
+version = "0.4.63+curl-8.1.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -100,7 +100,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "8.1.0"),
+            .replace("@CURLVERSION@", "8.1.2"),
     )
     .unwrap();
 

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -1,5 +1,5 @@
 #![allow(bad_style)]
-#![doc(html_root_url = "https://docs.rs/curl-sys/0.3")]
+#![doc(html_root_url = "https://docs.rs/curl-sys/0.4")]
 
 // These `extern crate` are required for conditional linkages of curl.
 #[cfg(link_libnghttp2)]


### PR DESCRIPTION
There were some minor bug fixes in 8.1.1 and 8.1.2 recently:
https://curl.se/changes.html#8_1_1
https://curl.se/changes.html#8_1_2
