### PR TITLE
Only update the curl submodule

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -39,7 +39,7 @@ fn main() {
 
     if !Path::new("curl/.git").exists() {
         let _ = Command::new("git")
-            .args(&["submodule", "update", "--init"])
+            .args(&["submodule", "update", "--init", "curl"])
             .status();
     }
 


### PR DESCRIPTION
Running `git submodule update --init` will trigger and update on all submodules including those in any repository that depends on curl-sys. This will break builds on partial checkouts.