### PR TITLE
 Allow running vcpkg on any Windows target

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -35,12 +35,10 @@ openssl-sys = { version = "0.9.64", optional = true }
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winsock2", "ws2def"] }
 
-[target.'cfg(target_env = "msvc")'.build-dependencies]
-vcpkg = "0.2"
-
 [build-dependencies]
 pkg-config = "0.3.3"
 cc = "1.0"
+vcpkg = "0.2"
 
 [features]
 default = ["ssl"]

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -446,12 +446,6 @@ fn main() {
     }
 }
 
-#[cfg(not(target_env = "msvc"))]
-fn try_vcpkg() -> bool {
-    false
-}
-
-#[cfg(target_env = "msvc")]
 fn try_vcpkg() -> bool {
     // the import library for the dll is called libcurl_imp
     let mut successful_probe_details = match vcpkg::Config::new()


### PR DESCRIPTION
`vcpkg-rs` doesn't support `-pc-windows-gnu` (mingw) _yet_, but its integration tests will try to build `curl-sys`, which currently prevents using `vcpkg` for non-`msvc` targets.

This change should have no effect for `curl-sys` right now, but [unblocks that work](https://github.com/mcgoo/vcpkg-rs/pull/52).