### PR TITLE
Update libcurl to 8.2.0

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.63+curl-8.1.2"
+version = "0.4.64+curl-8.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -100,7 +100,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "8.1.2"),
+            .replace("@CURLVERSION@", "8.2.0"),
     )
     .unwrap();
 
@@ -180,6 +180,7 @@ fn main() {
         .file("curl/lib/llist.c")
         .file("curl/lib/md5.c")
         .file("curl/lib/mime.c")
+        .file("curl/lib/macos.c")
         .file("curl/lib/mprintf.c")
         .file("curl/lib/mqtt.c")
         .file("curl/lib/multi.c")


### PR DESCRIPTION
Updates libcurl from 8.1.2 to 8.2.0

Changelog: https://curl.se/changes.html#8_2_0

There is one fixed CVE in this release:
[CVE-2023-32001](https://curl.se/docs/CVE-2023-32001.html) — fopen race condition