### PR TITLE
Update to curl 8.2.1

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.64+curl-8.2.0"
+version = "0.4.65+curl-8.2.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -100,7 +100,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "8.2.0"),
+            .replace("@CURLVERSION@", "8.2.1"),
     )
     .unwrap();
 


### PR DESCRIPTION
Updates libcurl from 8.2.0 to 8.2.1

Changelog: https://curl.se/changes.html#8_2_1
Summary: https://daniel.haxx.se/blog/2023/07/26/curl-8-2-1/

This fixes a few regressions in the last release.
