### PR TITLE
Fix semantic of `HttpVersion::V3` for  libcurl >= 7.88.0

### DIFF
--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -660,7 +660,7 @@ pub const CURL_HTTP_VERSION_2TLS: c_int = 4;
 /// Please use HTTP 2 without HTTP/1.1 Upgrade
 /// (Added in CURL 7.49.0)
 pub const CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE: c_int = 5;
-/// Makes use of explicit HTTP/3 without fallback.
+/// Use HTTP/3, fallback to HTTP/2 or HTTP/1 if needed.
 /// (Added in CURL 7.66.0)
 pub const CURL_HTTP_VERSION_3: c_int = 30;
 

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -453,12 +453,11 @@ pub enum HttpVersion {
     V2PriorKnowledge = curl_sys::CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE as isize,
 
     /// Setting this value will make libcurl attempt to use HTTP/3 directly to
-    /// server given in the URL. Note that this cannot gracefully downgrade to
-    /// earlier HTTP version if the server doesn't support HTTP/3.
+    /// server given in the URL but fallback to earlier HTTP versions if the HTTP/3
+    /// connection establishment fails.
     ///
-    /// For more reliably upgrading to HTTP/3, set the preferred version to
-    /// something lower and let the server announce its HTTP/3 support via
-    /// Alt-Svc:.
+    /// Note: the meaning of this settings depends on the linked libcurl.
+    /// For CURL < 7.88.0, there is no fallback if HTTP/3 connection fails.
     ///
     /// (Added in CURL 7.66.0)
     V3 = curl_sys::CURL_HTTP_VERSION_3 as isize,


### PR DESCRIPTION
CURL_HTTP_VERSION_3, introduced in curl 7.66.0, has changed with curl 7.88.0. Prior 7.88.0, CURL_HTTP_VERSION_3 implies no fallback if error; since 7.88.0, CURL_HTTP_VERSION_3 can fallback to HTTP/1 or HTTP/2. There is a new flag CURL_HTTP_VERSION_3_ONLY that doesn't fallback. See https://github.com/curl/curl/pull/10264.

Fixes #519.