### PR TITLE
Fix suspicious_double_ref_op warning

### DIFF
--- a/tests/server/mod.rs
+++ b/tests/server/mod.rs
@@ -59,7 +59,7 @@ fn run(stream: impl Read + Write, rx: &Receiver<Message>) {
                     let mut found = None;
                     for header in expected_headers.iter() {
                         if lines_match(header, &actual) {
-                            found = Some(header.clone());
+                            found = Some(*header);
                             break;
                         }
                     }


### PR DESCRIPTION
rustc recently added the [`suspicious_double_ref_op`](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#suspicious-double-ref-op) diagnostic which warns about trying to clone a double reference (which doesn't clone the underlying type).
