### PR TITLE
Update to curl 8.4.0

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.67+curl-8.3.0"
+version = "0.4.68+curl-8.4.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -100,7 +100,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "8.3.0"),
+            .replace("@CURLVERSION@", "8.4.0"),
     )
     .unwrap();
 

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -140,7 +140,6 @@ fn upload_lots() {
 
     let e = t!(m.add(h));
 
-    assert!(t!(m.perform()) > 0);
     let mut next_token = 1;
     let mut token_map = HashMap::new();
     let mut cur_timeout = None;

--- a/tests/post.rs
+++ b/tests/post.rs
@@ -23,6 +23,7 @@ fn handle() -> Easy {
     e
 }
 
+#[cfg(feature = "static-curl")]
 #[test]
 fn custom() {
     let s = Server::new();
@@ -31,7 +32,7 @@ fn custom() {
          POST / HTTP/1.1\r\n\
          Host: 127.0.0.1:$PORT\r\n\
          Accept: */*\r\n\
-         Content-Length: 142\r\n\
+         Content-Length: 154\r\n\
          Content-Type: multipart/form-data; boundary=--[..]\r\n\
          \r\n\
          --[..]\r\n\
@@ -50,6 +51,7 @@ fn custom() {
     t!(handle.perform());
 }
 
+#[cfg(feature = "static-curl")]
 #[test]
 fn buffer() {
     let s = Server::new();
@@ -58,7 +60,7 @@ fn buffer() {
          POST / HTTP/1.1\r\n\
          Host: 127.0.0.1:$PORT\r\n\
          Accept: */*\r\n\
-         Content-Length: 181\r\n\
+         Content-Length: 193\r\n\
          Content-Type: multipart/form-data; boundary=--[..]\r\n\
          \r\n\
          --[..]\r\n\
@@ -82,6 +84,7 @@ fn buffer() {
     t!(handle.perform());
 }
 
+#[cfg(feature = "static-curl")]
 #[test]
 fn file() {
     let s = Server::new();
@@ -102,7 +105,7 @@ fn file() {
              {}\
              \r\n\
              --[..]\r\n",
-            199 + formdata.len(),
+            211 + formdata.len(),
             formdata
         )
         .as_str(),


### PR DESCRIPTION
cURL 8.4.0 fixes two vulnerabilities:

- [CVE-2023-38545](https://curl.se/docs/CVE-2023-38545.html), high severity
- [CVE-2023-38546](https://curl.se/docs/CVE-2023-38546.html)
