### PR TITLE
Add Win32_Foundation feature to windows-sys dep.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ openssl-probe = { version = "0.1.2", optional = true }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 schannel = "0.1.13"
-windows-sys = { version = "0.52", features = ["Win32_System_LibraryLoader", "Win32_Security_Cryptography"] }
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security_Cryptography"] }
 
 [dev-dependencies]
 mio = "0.6"


### PR DESCRIPTION
This is needed by the following functions we use in the easy API
Windows suppport:
+ `windows_sys::Win32::System::LibraryLoader::GetProcAddress`
+ `windows_sys::Win32::System::LibraryLoader::GetModuleHandleW`