### PR TITLE
Set minimum version of the curl-sys crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl"
-version = "0.4.45"
+version = "0.4.46"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT"
 repository = "https://github.com/alexcrichton/curl-rust"
@@ -18,7 +18,7 @@ appveyor = { repository = "alexcrichton/curl-rust" }
 
 [dependencies]
 libc = "0.2.42"
-curl-sys = { path = "curl-sys", version = "0.4.59", default-features = false }
+curl-sys = { path = "curl-sys", version = "0.4.72", default-features = false }
 socket2 = "0.5.0"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality


### PR DESCRIPTION
This sets the minimum version of `curl-sys` to the latest to ensure that the correct version of `curl-sys` is used.

Closes #548