### PR TITLE
Un-pin nightly in CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - build: x86_64-nightly
             os: ubuntu-latest
-            rust: nightly-2024-02-01
+            rust: nightly
             docker: linux64
             target: x86_64-unknown-linux-gnu
           - build: i686


### PR DESCRIPTION
Releases of garando_syntax 0.1.1 and ctest2 0.4.8 fix the issues that
required the pin.