### PR TITLE
Remove redundant imports.

### DIFF
--- a/src/easy/form.rs
+++ b/src/easy/form.rs
@@ -5,7 +5,6 @@ use std::ptr;
 
 use crate::easy::{list, List};
 use crate::FormError;
-use curl_sys;
 
 /// Multipart/formdata for an HTTP POST request.
 ///

--- a/src/easy/handle.rs
+++ b/src/easy/handle.rs
@@ -6,7 +6,6 @@ use std::ptr;
 use std::str;
 use std::time::Duration;
 
-use curl_sys;
 use libc::c_void;
 
 use crate::easy::handler::{self, InfoType, ReadError, SeekResult, WriteError};

--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -9,8 +9,7 @@ use std::slice;
 use std::str;
 use std::time::Duration;
 
-use curl_sys;
-use libc::{self, c_char, c_double, c_int, c_long, c_ulong, c_void, size_t};
+use libc::{c_char, c_double, c_int, c_long, c_ulong, c_void, size_t};
 use socket2::Socket;
 
 use crate::easy::form;

--- a/src/easy/list.rs
+++ b/src/easy/list.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::ptr;
 
 use crate::Error;
-use curl_sys;
 
 /// A linked list of a strings
 pub struct List {

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -6,7 +6,6 @@ use std::ptr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use curl_sys;
 use libc::{c_char, c_int, c_long, c_short, c_void};
 
 #[cfg(unix)]


### PR DESCRIPTION
The latest nightly has started warning against redundant imports.