### PR TITLE
Exclude curl/docs and curl/tests from curl-sys crate

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -10,6 +10,7 @@ description = "Native bindings to the libcurl library"
 documentation = "https://docs.rs/curl-sys"
 categories = ["external-ffi-bindings"]
 edition = "2018"
+exclude = ["curl/docs/", "curl/tests/"]
 
 [badges]
 travis-ci = { repository = "alexcrichton/curl-rust" }


### PR DESCRIPTION
These directories within the curl submodule are 5 and 11 MB, respectively, and are not necessary for building curl-sys.