### PR TITLE
use vcpkg only from `*-msvc` targets

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -7,6 +7,7 @@ fn main() {
     println!("cargo:rerun-if-changed=curl");
     let target = env::var("TARGET").unwrap();
     let windows = target.contains("windows");
+    let msvc = target.contains("msvc");
 
     if cfg!(feature = "mesalink") {
         println!("cargo:warning=MesaLink support has been removed as of curl 7.82.0, will use default TLS backend instead.");
@@ -28,7 +29,7 @@ fn main() {
         }
 
         // Next, fall back and try to use pkg-config if its available.
-        if windows {
+        if msvc {
             if try_vcpkg() {
                 return;
             }


### PR DESCRIPTION
for other targets (`*-gnu` and `*-gnullvm`) pkg-config is usually used