### PR TITLE
Update rustls-ffi version to fix vulnerability

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -26,7 +26,7 @@ libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1.3" }
 
 [dependencies.rustls-ffi]
-version = "0.8"
+version = "0.13"
 optional = true
 features = ["no_log_capture"]
 


### PR DESCRIPTION
When auditing my crate, I found out that this package needed an update.

> Crate:     rustls
> Version:   0.20.9
> Title:     `rustls::ConnectionCommon::complete_io` could fall into an infinite loop based on network input
> Date:      2024-04-19
> ID:        RUSTSEC-2024-0336
> URL:       https://rustsec.org/advisories/RUSTSEC-2024-0336
> Severity:  7.5 (high)
> Solution:  Upgrade to >=0.23.5 OR >=0.22.4, <0.23.0 OR >=0.21.11, <0.22.0
> Dependency tree:
> rustls 0.20.9
> └── rustls-ffi 0.8.2
>   .  └── curl-sys 0.4.72+curl-8.6.0
>   .    . └── curl 0.4.46
>   .    .   . └── faker 0.1.0

I updated rustls-ffi to the latest version, and it seems to work with no additional changes.

What I did to test:
- cargo clean
- cargo build --release
- cargo build --release -F rustls
- cargo test --release
- cargo test --release -F rustls