### PR TITLE
Squelch check-cfg warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,12 @@
 use std::env;
 
 fn main() {
+    println!(
+        "cargo::rustc-check-cfg=cfg(\
+            need_openssl_init,\
+            need_openssl_probe,\
+        )"
+    );
     // OpenSSL >= 1.1.0 can be initialized concurrently and is initialized correctly by libcurl.
     // <= 1.0.2 need locking callbacks, which are provided by openssl_sys::init().
     let use_openssl = match env::var("DEP_OPENSSL_VERSION_NUMBER") {

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -5,6 +5,14 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=curl");
+    println!(
+        "cargo::rustc-check-cfg=cfg(\
+            libcurl_vendored,\
+            link_libnghttp2,\
+            link_libz,\
+            link_openssl,\
+        )"
+    );
     let target = env::var("TARGET").unwrap();
     let windows = target.contains("windows");
 


### PR DESCRIPTION
This removes the warnings about unexpected cfg values introduced in Rust 1.80.
