### PR TITLE
Use cargo: (universally supported) instead of cargo:: (1.80+ only) syntax for rustc-check-cfg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,11 @@ jobs:
             rust: stable
             docker: linux64
             target: x86_64-unknown-linux-gnu
+          - build: ubuntu-lts
+            os: ubuntu-24.04
+            rust: 1.75
+            docker: linux64
+            target: x86_64-unknown-linux-gnu
           - build: x86_64-beta
             os: ubuntu-latest
             rust: beta

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     println!(
-        "cargo::rustc-check-cfg=cfg(\
+        "cargo:rustc-check-cfg=cfg(\
             need_openssl_init,\
             need_openssl_probe,\
         )"

--- a/ci/Dockerfile-musl
+++ b/ci/Dockerfile-musl
@@ -6,7 +6,7 @@ RUN apt-get install -y --no-install-recommends \
   musl-tools
 
 RUN \
-  curl https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz | tar xzf - && \
+  curl -L https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz | tar xzf - && \
   cd openssl-1.0.2g && \
   CC=musl-gcc ./Configure --prefix=/openssl no-dso linux-x86_64 -fPIC && \
   make -j10 && \

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 fn main() {
     println!("cargo:rerun-if-changed=curl");
     println!(
-        "cargo::rustc-check-cfg=cfg(\
+        "cargo:rustc-check-cfg=cfg(\
             libcurl_vendored,\
             link_libnghttp2,\
             link_libz,\


### PR DESCRIPTION
Ref: #575
Closes #576
Closes https://github.com/nabijaczleweli/cargo-update/issues/277
Supplants #577