### PR TITLE
Use openssl-src instead of building OpenSSL manually

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         build: [x86_64, i686, x86_64-musl, mingw, system-curl, openssl-110, x86_64-beta, x86_64-nightly, macos, win64, win32]
         include:

--- a/ci/Dockerfile-musl
+++ b/ci/Dockerfile-musl
@@ -3,16 +3,4 @@ FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc ca-certificates make libc6-dev curl \
-  musl-tools
-
-RUN \
-  curl -L https://www.openssl.org/source/old/1.0.2/openssl-1.0.2g.tar.gz | tar xzf - && \
-  cd openssl-1.0.2g && \
-  CC=musl-gcc ./Configure --prefix=/openssl no-dso linux-x86_64 -fPIC && \
-  make -j10 && \
-  make install && \
-  cd .. && \
-  rm -rf openssl-1.0.2g
-
-ENV OPENSSL_STATIC=1 \
-    OPENSSL_DIR=/openssl
+  musl-tools perl

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -13,3 +13,6 @@ libc = "0.2"
 [build-dependencies]
 ctest2 = "0.4"
 cc = "1.0"
+
+[features]
+static-ssl = ['curl-sys/static-ssl']


### PR DESCRIPTION
Also turn off `fail-fast` on CI to see all the failures on PRs