### PR TITLE
Update to 8.11.0

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.77+curl-8.10.1"
+version = "0.4.78+curl-8.11.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -108,7 +108,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "8.10.1"),
+            .replace("@CURLVERSION@", "8.11.0"),
     )
     .unwrap();
 
@@ -132,7 +132,7 @@ fn main() {
         .define("ENABLE_IPV6", None)
         .define("HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID", None)
         .define("HAVE_ASSERT_H", None)
-        .define("OS", "\"unknown\"") // TODO
+        .define("CURL_OS", "\"unknown\"") // TODO
         .define("HAVE_ZLIB_H", None)
         .define("HAVE_LONGLONG", None)
         .define("HAVE_LIBZ", None)
@@ -236,6 +236,7 @@ fn main() {
         .file("curl/lib/vtls/vtls.c")
         .file("curl/lib/warnless.c")
         .file("curl/lib/timediff.c")
+        .file("curl/lib/ws.c")
         .define("HAVE_GETADDRINFO", None)
         .define("HAVE_GETPEERNAME", None)
         .define("HAVE_GETSOCKNAME", None)


### PR DESCRIPTION
Updates to 8.11.0.

https://daniel.haxx.se/blog/2024/11/06/curl-8-11-0/

One CVE fix:

https://curl.se/docs/CVE-2024-9681.html
