### PR TITLE
Update to 8.12.0

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.78+curl-8.11.0"
+version = "0.4.79+curl-8.12.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -108,7 +108,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "8.11.0"),
+            .replace("@CURLVERSION@", "8.12.0"),
     )
     .unwrap();
 
@@ -216,6 +216,7 @@ fn main() {
         .file("curl/lib/strcase.c")
         .file("curl/lib/strdup.c")
         .file("curl/lib/strerror.c")
+        .file("curl/lib/strparse.c")
         .file("curl/lib/strtok.c")
         .file("curl/lib/strtoofft.c")
         .file("curl/lib/timeval.c")
@@ -234,6 +235,7 @@ fn main() {
         .file("curl/lib/vtls/hostcheck.c")
         .file("curl/lib/vtls/keylog.c")
         .file("curl/lib/vtls/vtls.c")
+        .file("curl/lib/vtls/vtls_scache.c")
         .file("curl/lib/warnless.c")
         .file("curl/lib/timediff.c")
         .file("curl/lib/ws.c")


### PR DESCRIPTION
Updates to curl 8.12.0

Release notes: https://curl.se/ch/8.12.0.html
Blog: https://daniel.haxx.se/blog/2025/02/05/curl-8-12-0/
