### PR TITLE
Update curl to 8.12.1

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.79+curl-8.12.0"
+version = "0.4.80+curl-8.12.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -108,7 +108,7 @@ fn main() {
             .replace("@LIBCURL_LIBS@", "")
             .replace("@SUPPORT_FEATURES@", "")
             .replace("@SUPPORT_PROTOCOLS@", "")
-            .replace("@CURLVERSION@", "8.12.0"),
+            .replace("@CURLVERSION@", "8.12.1"),
     )
     .unwrap();
 


### PR DESCRIPTION
Release notes: https://curl.se/ch/8.12.1.html
Blog: https://daniel.haxx.se/blog/2025/02/13/curl-8-12-1/

I can't tell if any of these fixes look particularly important. However, it's fairly trivial to bump the submodule.