### PR TITLE
Bump `windows-sys` dependency to ver 0.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ openssl-probe = { version = "0.1.2", optional = true }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 schannel = "0.1.13"
-windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security_Cryptography"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security_Cryptography"] }
 
 [dev-dependencies]
 mio = "0.6"

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -30,7 +30,7 @@ features = ["no_log_capture"]
 openssl-sys = { version = "0.9.64", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = ["Win32_Networking_WinSock"] }
+windows-sys = { version = "0.59", features = ["Win32_Networking_WinSock"] }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"


### PR DESCRIPTION
Addresses #599 

Goal of this is making the `arm64ec-pc-windows-msvc` target triple compile.