### PR TITLE
Use LazyLock for openssl probe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - build: ubuntu-lts
             os: ubuntu-24.04
-            rust: 1.75
+            rust: '1.80'
             docker: linux64
             target: x86_64-unknown-linux-gnu
           - build: x86_64-beta


### PR DESCRIPTION
This switches the global static openssl probe to use LazyLock instead of Once. `static mut` refs are now an error in Rust 2024, and this is I believe the preferred method of doing something like this.

LazyLock was added in 1.80 (released 2024-07-25), so the minimum version has to be bumped to that.