### PR TITLE
Expose CURL handle to write function via `Handler`

### DIFF
--- a/src/easy/context.rs
+++ b/src/easy/context.rs
@@ -1,0 +1,50 @@
+use std::fmt;
+
+use super::handle::EasyData;
+use super::handler::Inner;
+#[cfg(doc)]
+use super::{Easy, Handler};
+
+/// Provides access to the handle inside [`Handler::write`] callback.
+pub struct WriteContext2<H: ?Sized> {
+    inner: *mut Inner<H>,
+}
+
+/// Provides access to the handle inside [`Easy::write_function`] callback.
+#[repr(transparent)]
+pub struct WriteContext(WriteContext2<EasyData>);
+
+impl<H: ?Sized> WriteContext2<H> {
+    /// Returns the raw Easy pointer.
+    #[inline]
+    pub fn raw(&self) -> *mut curl_sys::CURL {
+        // Safety: make sure not to borrow `inner` that would be an alias to the inner handle
+        // activated in a Handler callback.
+        unsafe { *std::ptr::addr_of!((*self.inner).handle) }
+    }
+}
+
+impl WriteContext {
+    /// Returns the raw Easy pointer.
+    #[inline]
+    pub fn raw(&self) -> *mut curl_sys::CURL {
+        self.0.raw()
+    }
+
+    pub(super) fn from_mut(inner: &mut WriteContext2<EasyData>) -> &mut Self {
+        // Safety: `inner` has repr transparent over WriteContext2<EasyData>.
+        unsafe { std::mem::transmute::<&mut WriteContext2<EasyData>, &mut Self>(inner) }
+    }
+}
+
+impl<H: ?Sized> fmt::Debug for WriteContext2<H> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WriteContext2").finish()
+    }
+}
+
+impl fmt::Debug for WriteContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WriteContext").finish()
+    }
+}

--- a/src/easy/mod.rs
+++ b/src/easy/mod.rs
@@ -7,12 +7,14 @@
 //! Most simple usage of libcurl will likely use the `Easy` structure here, and
 //! you can find more docs about its usage on that struct.
 
+mod context;
 mod form;
 mod handle;
 mod handler;
 mod list;
 mod windows;
 
+pub use self::context::{WriteContext, WriteContext2};
 pub use self::form::{Form, Part};
 pub use self::handle::{Easy, Transfer};
 pub use self::handler::{Auth, NetRc, PostRedirections, ProxyType, SslOpt};


### PR DESCRIPTION
This MR adds a new provided method `write_context` to `Handler`. In addition to the data buffer, it passes a context reference to the `Handler` which allows the `Handler` to act on the raw handle inside the callback.

I need this capability to as part of the [ongoing WebSockets support](https://github.com/bdbai/curl-rust/tree/websocket). When working with the [writefunction model](https://curl.se/libcurl/c/libcurl-ws.html#MODELS), users should be able to get metadata from [`curl_ws_meta`](https://curl.se/libcurl/c/curl_ws_meta.html) or perform a blocking send using [`curl_ws_send`](https://curl.se/libcurl/c/curl_ws_send.html) from inside the write function callback. With the context object, we can park these two methods under there.