### PR TITLE
CI: Switch to aarch64-apple-darwin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           - build: macos
             os: macos-latest
             rust: stable
-            target: x86_64-apple-darwin
+            target: aarch64-apple-darwin
           - build: win32
             os: windows-latest
             rust: stable


### PR DESCRIPTION
This changes the macos CI job to use the aarch64-apple-darwin target instead of x86_64-apple-darwin. The Rust project has demoted x86_64 to tier 2
(https://rust-lang.github.io/rfcs/3841-demote-x86_64-apple-darwin.html), and I think we should be testing the aarch64-apple-darwin target instead since it is tier 1.

macos-latest is currently macos-14 which is aarch64. The x86_64 tests have been running under emulation.