### PR TITLE
Fix mismatched_lifetime_syntaxes warning

### DIFF
--- a/src/easy/list.rs
+++ b/src/easy/list.rs
@@ -46,7 +46,7 @@ impl List {
     }
 
     /// Returns an iterator over the nodes in this list.
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             _me: self,
             cur: self.raw,

--- a/src/version.rs
+++ b/src/version.rs
@@ -203,7 +203,7 @@ impl Version {
 
     /// Returns an iterator over the list of protocols that this build of
     /// libcurl supports.
-    pub fn protocols(&self) -> Protocols {
+    pub fn protocols(&self) -> Protocols<'_> {
         unsafe {
             Protocols {
                 _inner: self,


### PR DESCRIPTION
This fixes the mismatched_lifetime_syntaxes warning which has started to appear on more recent versions of rustc.