### PR TITLE
Remove `libclang_rt.osx.a` link workaround

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -2,6 +2,15 @@
 
 set -ex
 
+# On macOS, test with the deployment target set to Rust's minimum:
+# https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version
+if [ "$TARGET" = "x86_64-apple-darwin" ]; then
+  export MACOSX_DEPLOYMENT_TARGET=10.12
+fi
+if [ "$TARGET" = "aarch64-apple-darwin" ]; then
+  export MACOSX_DEPLOYMENT_TARGET=11.0
+fi
+
 # For musl on CI always use openssl-src dependency and build from there.
 if [ "$TARGET" = "x86_64-unknown-linux-musl" ]; then
   features="--features static-ssl"


### PR DESCRIPTION
We previously linked the Clang runtime `libclang_rt.osx.a` to fix https://github.com/alexcrichton/curl-rust/issues/279.

All current usage of `__builtin_available(...)` in curl detects for APIs older than macOS 10.12, which is [Rust's currently minimum supported version](https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version). This means that they are no-ops, and thus no longer emit a symbol that we need to link.

Additionally, Rust's `std` has recently introduced these symbols in its standard library, see https://github.com/rust-lang/rust/pull/138944. This means that even if curl _were_ to start using `__builtin_available` with a check for a newer macOS version, it would still successfully link (at least when using Rust 1.91.0 or newer).

Finally, curl has supported the cfg option `HAVE_BUILTIN_AVAILABLE` for a while now, so if there ever does come a point where this starts having problems again, we can just disable that define.

Motivation: This makes cross-compiling from some other host to macOS slightly easier.