### PR TITLE
Try pkg-config on Windows targets

### DIFF
--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -40,7 +40,8 @@ fn main() {
             if try_vcpkg() {
                 return;
             }
-        } else if try_pkg_config() {
+        }
+        if try_pkg_config() {
             return;
         }
     }


### PR DESCRIPTION
pkg-config is still useful to be tried on Windows targets, mainly when building with MinGW.