### PR TITLE
Fix doc tests: uses https://rust-lang.org instead of https://www.rust-lang.org

### DIFF
--- a/src/easy/handler.rs
+++ b/src/easy/handler.rs
@@ -43,7 +43,7 @@ use crate::Error;
 ///
 /// let mut easy = Easy2::new(Collector(Vec::new()));
 /// easy.get(true).unwrap();
-/// easy.url("https://www.rust-lang.org/").unwrap();
+/// easy.url("https://rust-lang.org/").unwrap();
 /// easy.perform().unwrap();
 ///
 /// assert_eq!(easy.response_code().unwrap(), 200);
@@ -368,7 +368,7 @@ pub fn ssl_ctx(cx: *mut c_void) -> Result<(), Error> {
 ///
 /// let mut easy = Easy2::new(Collector(Vec::new()));
 /// easy.get(true).unwrap();
-/// easy.url("https://www.rust-lang.org/").unwrap();
+/// easy.url("https://rust-lang.org/").unwrap();
 /// easy.perform().unwrap();
 ///
 /// assert_eq!(easy.response_code().unwrap(), 200);


### PR DESCRIPTION
This PR fixes running `cargo test`: 2 doc samples are failing now because <https://www.rust-lang.org> is a 301 to <https://rust-lang.org> now.