### PR TITLE
fix(sys): link to `iphlpapi` unconditionally

### DIFF
--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curl-sys"
-version = "0.4.86+curl-8.19.0"
+version = "0.4.87+curl-8.19.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "curl"
 build = "build.rs"

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -458,6 +458,7 @@ fn main() {
     if windows {
         println!("cargo:rustc-link-lib=ws2_32");
         println!("cargo:rustc-link-lib=crypt32");
+        println!("cargo:rustc-link-lib=iphlpapi");
     }
 
     // Illumos/Solaris requires explicit linking with libnsl


### PR DESCRIPTION
Upstream has done that so we follow:

1. curl/curl#17413 preloads `iphlpapi` conditioned on `HAVE_IF_NAMETOINDEX`
2. curl/curl@b17ef873 `HAVE_IF_NAMETOINDEX` is defined unconditionally

See rust-lang/rust#154482 which [failed without](https://github.com/rust-lang/rust/pull/154482#issuecomment-4148090768) and [succeeded with](https://github.com/rust-lang/rust/pull/154482#issuecomment-4148609723) link to `iphlpai` dll.

This also bumps curl-sys to 0.4.87 to help unblock rust-lang/rust#154482, (of course, if curl-rust maintainers can help release 🙏🏾)