### PR TITLE
chore: `-Clink-dead-code` always

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+# Note that `-Clink-dead-code` is passed here to suppress `--gc-sections` to
+# help confirm that we're compiling everything necessary for curl itself.
+export RUSTFLAGS=-Clink-dead-code
+
 # On macOS, test with the deployment target set to Rust's minimum:
 # https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version
 if [ "$TARGET" = "x86_64-apple-darwin" ]; then
@@ -16,9 +20,9 @@ if [ "$TARGET" = "x86_64-unknown-linux-musl" ]; then
   features="--features static-ssl"
 fi
 
-cargo test --target $TARGET --no-run $features
+cargo test --target $TARGET --no-run $features --release
 # First test with no extra protocols enabled.
-cargo test --target $TARGET --no-run --features static-curl $features
+cargo test --target $TARGET --no-run --features static-curl $features --release
 # Then with rustls TLS backend.
 #
 # Note: Cross-compiling rustls on windows doesn't work due to requiring some
@@ -30,23 +34,19 @@ cargo test --target $TARGET --no-run --features static-curl $features
 # inconvenience for me.
 if [ "$TARGET" != "x86_64-pc-windows-gnu" ] && [ "$TARGET" != "i686-pc-windows-msvc" ]
 then
-    cargo test --target $TARGET --no-run --features rustls,static-curl $features
+    cargo test --target $TARGET --no-run --features rustls,static-curl $features --release
 fi
 # Then with all extra protocols enabled.
-cargo test --target $TARGET --no-run --features static-curl,protocol-ftp,ntlm $features
+cargo test --target $TARGET --no-run --features static-curl,protocol-ftp,ntlm $features --release
 if [ -z "$NO_RUN" ]; then
-    cargo test --target $TARGET $features
-    cargo test --target $TARGET --features static-curl $features
-    cargo test --target $TARGET --features static-curl,protocol-ftp $features
-    cargo test --target $TARGET --features static-curl,http2 $features
+    cargo test --target $TARGET $features --release
+    cargo test --target $TARGET --features static-curl $features --release
+    cargo test --target $TARGET --features static-curl,protocol-ftp $features --release
+    cargo test --target $TARGET --features static-curl,http2 $features --release
 
-    # Note that `-Clink-dead-code` is passed here to suppress `--gc-sections` to
-    # help confirm that we're compiling everything necessary for curl itself.
-    RUSTFLAGS=-Clink-dead-code \
-    cargo run --manifest-path systest/Cargo.toml --target $TARGET $features
-    RUSTFLAGS=-Clink-dead-code \
-    cargo run --manifest-path systest/Cargo.toml --target $TARGET --features curl-sys/static-curl,curl-sys/protocol-ftp $features
+    cargo run --manifest-path systest/Cargo.toml --target $TARGET $features --release
+    cargo run --manifest-path systest/Cargo.toml --target $TARGET --features curl-sys/static-curl,curl-sys/protocol-ftp $features --release
 
-    cargo doc --no-deps --target $TARGET $features
-    cargo doc --no-deps -p curl-sys --target $TARGET $features
+    cargo doc --no-deps --target $TARGET $features --release
+    cargo doc --no-deps -p curl-sys --target $TARGET $features --release
 fi


### PR DESCRIPTION
`-Clink-dead-code` is passed here to suppress `--gc-sections` to help confirm that we're compiling everything necessary for curl itself.

I am not sure why systest didn't catch that though.