### PR TITLE
Update MSRV to 1.82

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - build: ubuntu-lts
             os: ubuntu-24.04
-            rust: '1.80'
+            rust: '1.82'
             docker: linux64
             target: x86_64-unknown-linux-gnu
           - build: x86_64-beta


### PR DESCRIPTION
libnghttp2-sys has been updated to use new syntax (`unsafe extern`) that is not available in 1.80.