### PR TITLE
Consolidate some dependency versions into workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ socket2 = "0.6.0"
 
 # Unix platforms use OpenSSL for now to provide SSL functionality
 [target.'cfg(all(unix))'.dependencies]
-openssl-sys = { version = "0.9.64", optional = true }
+openssl-sys = { workspace = true, optional = true }
 openssl-probe = { version = "0.1.2", optional = true }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 schannel = "0.1.13"
-windows-sys = { version = ">=0.59.0, <0.62.0", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security_Cryptography"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security_Cryptography"] }
 
 [dev-dependencies]
 mio = "0.6"
@@ -33,6 +33,11 @@ anyhow = "1.0.31"
 
 [workspace]
 members = ["systest"]
+
+[workspace.dependencies]
+cc = "1.0"
+openssl-sys = "0.9.64"
+windows-sys = ">=0.59.0, <0.62.0"
 
 [features]
 default = ["ssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ mio-extras = "2.0.3"
 anyhow = "1.0.31"
 
 [workspace]
-members = ["systest"]
+members = ["curl-sys", "systest"]
 
 [workspace.dependencies]
 cc = "1.0"

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -27,17 +27,17 @@ optional = true
 features = ["no_log_capture"]
 
 [target.'cfg(all(unix))'.dependencies]
-openssl-sys = { version = "0.9.64", optional = true }
+openssl-sys = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = ">=0.59.0, <0.62.0", features = ["Win32_Networking_WinSock"] }
+windows-sys = { workspace = true, features = ["Win32_Networking_WinSock"] }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"
 
 [build-dependencies]
+cc.workspace = true
 pkg-config = "0.3.3"
-cc = "1.0"
 
 [features]
 default = ["ssl"]

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -11,8 +11,8 @@ curl-sys = { path = "../curl-sys" }
 libc = "0.2"
 
 [build-dependencies]
+cc.workspace = true
 ctest2 = "0.4"
-cc = "1.0"
 
 [features]
 static-ssl = ['curl-sys/static-ssl']


### PR DESCRIPTION
Consolidate some repeated dependency versions into workspace dependencies so that they can be more easily kept in sync across `curl` and `curl-sys` and with less repetition.