### PR TITLE
Add HTTP/3 support through the already stable ngtcp2 libcurl back-end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ default = ["ssl"]
 ssl = ["openssl-sys", "openssl-probe", "curl-sys/ssl"] # OpenSSL/system TLS backend
 mesalink = ["curl-sys/mesalink"] # MesaLink TLS backend
 http2 = ["curl-sys/http2"]
+http3 = ["curl-sys/http3"]
 spnego = ["curl-sys/spnego"]
 rustls = ["curl-sys/rustls"]
 static-curl = ["curl-sys/static-curl"]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ with various Cargo features:
 
   Note that Rustls support is experimental within Curl itself and may have significant bugs, so we don't offer any sort of stability guarantee with this feature.
 - `http2`: Enable HTTP/2 support via libnghttp2. Disabled by default.
+- `http3`: Enable HTTP/3 support via ngtcp2 and nghttp3 using AWS-LC as the TLS backend. This TLS backend takes precedence over the `ssl` and `rustls` features. Disabled by default.
 - `static-curl`: Use a bundled libcurl version and statically link to it. Disabled by default.
 - `static-ssl`: Use a bundled OpenSSL version and statically link to it. Only applies on platforms that use OpenSSL. Disabled by default.
 - `spnego`: Enable SPNEGO support. Disabled by default.

--- a/curl-sys/Cargo.toml
+++ b/curl-sys/Cargo.toml
@@ -20,6 +20,9 @@ path = "lib.rs"
 libz-sys = { version = "1.0.18", default-features = false, features = ["libc"] }
 libc = "0.2.2"
 libnghttp2-sys = { optional = true, version = "0.1.3" }
+nghttp3-sys = { optional = true, version = "0.2" }
+ngtcp2-sys = { optional = true, version = "0.2" }
+aws-lc-sys = { optional = true, version = "0.43", features = ["ssl"] }
 
 [dependencies.rustls-ffi]
 version = "0.15"
@@ -43,6 +46,7 @@ pkg-config = "0.3.3"
 default = ["ssl"]
 ssl = ["openssl-sys"]
 http2 = ["libnghttp2-sys"]
+http3 = ["nghttp3-sys", "ngtcp2-sys", "aws-lc-sys"]
 mesalink = []
 rustls = ["rustls-ffi"]
 static-curl = []

--- a/curl-sys/build.rs
+++ b/curl-sys/build.rs
@@ -8,7 +8,10 @@ fn main() {
     println!(
         "cargo:rustc-check-cfg=cfg(\
             libcurl_vendored,\
+            link_aws_lc,\
             link_libnghttp2,\
+            link_libnghttp3,\
+            link_libngtcp2,\
             link_libz,\
             link_openssl,\
         )"
@@ -31,7 +34,10 @@ fn main() {
     if !cfg!(feature = "static-curl") {
         // OSX ships libcurl by default, so we just use that version
         // so long as it has the right features enabled.
-        if target.contains("apple") && (!cfg!(feature = "http2") || curl_config_reports_http2()) {
+        if target.contains("apple")
+            && (!cfg!(feature = "http2") || curl_config_reports("HTTP2", "http-2"))
+            && (!cfg!(feature = "http3") || curl_config_reports("HTTP3", "http-3"))
+        {
             return println!("cargo:rustc-flags=-l curl");
         }
 
@@ -300,6 +306,22 @@ fn main() {
         }
     }
 
+    if cfg!(feature = "http3") {
+        cfg.define("USE_NGTCP2", None)
+            .define("USE_NGHTTP3", None)
+            .define("NGTCP2_STATICLIB", None)
+            .define("NGHTTP3_STATICLIB", None)
+            .file("curl/lib/vquic/cf-ngtcp2.c")
+            .file("curl/lib/vquic/cf-ngtcp2-cmn.c");
+
+        println!("cargo:rustc-cfg=link_aws_lc");
+        println!("cargo:rustc-cfg=link_libnghttp3");
+        println!("cargo:rustc-cfg=link_libngtcp2");
+        cfg.include(env::var_os("DEP_NGTCP2_INCLUDE").unwrap())
+            .include(env::var_os("DEP_NGHTTP3_INCLUDE").unwrap())
+            .include(aws_lc_include().unwrap());
+    }
+
     println!("cargo:rustc-cfg=link_libz");
     if let Some(path) = env::var_os("DEP_Z_INCLUDE") {
         cfg.include(path);
@@ -313,7 +335,11 @@ fn main() {
 
     // Configure TLS backend. Since Cargo does not support mutually exclusive
     // features, make sure we only compile one vtls.
-    if cfg!(feature = "rustls") {
+    if cfg!(feature = "http3") {
+        cfg.define("USE_OPENSSL", None)
+            .define("OPENSSL_IS_AWSLC", None)
+            .file("curl/lib/vtls/openssl.c");
+    } else if cfg!(feature = "rustls") {
         cfg.define("USE_RUSTLS", None)
             .file("curl/lib/vtls/cipher_suite.c")
             .file("curl/lib/vtls/rustls.c")
@@ -558,9 +584,11 @@ fn try_pkg_config() -> bool {
         }
     };
 
-    // Not all system builds of libcurl have http2 features enabled, so if we've
-    // got a http2-requested build then we may fall back to a build from source.
-    if cfg!(feature = "http2") && !curl_config_reports_http2() {
+    // Not all system builds of libcurl have optional HTTP features enabled, so
+    // fall back to a source build when a requested feature is missing.
+    if (cfg!(feature = "http2") && !curl_config_reports("HTTP2", "http-2"))
+        || (cfg!(feature = "http3") && !curl_config_reports("HTTP3", "http-3"))
+    {
         return false;
     }
 
@@ -573,7 +601,7 @@ fn try_pkg_config() -> bool {
     true
 }
 
-fn curl_config_reports_http2() -> bool {
+fn curl_config_reports(feature: &str, description: &str) -> bool {
     let output = Command::new("curl-config").arg("--features").output();
     let output = match output {
         Ok(out) => out,
@@ -587,13 +615,21 @@ fn curl_config_reports_http2() -> bool {
         return false;
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    if !stdout.contains("HTTP2") {
+    if !stdout.split_whitespace().any(|item| item == feature) {
         println!(
-            "failed to find http-2 feature enabled in pkg-config-found \
-             libcurl, building from source"
+            "failed to find {} feature enabled in pkg-config-found \
+             libcurl, building from source",
+            description
         );
         return false;
     }
 
     true
+}
+
+fn aws_lc_include() -> Option<std::ffi::OsString> {
+    env::vars_os().find_map(|(key, value)| {
+        let key = key.to_string_lossy();
+        (key.starts_with("DEP_AWS_LC_") && key.ends_with("_INCLUDE")).then_some(value)
+    })
 }

--- a/curl-sys/lib.rs
+++ b/curl-sys/lib.rs
@@ -2,10 +2,16 @@
 #![doc(html_root_url = "https://docs.rs/curl-sys/0.4")]
 
 // These `extern crate` are required for conditional linkages of curl.
+#[cfg(link_aws_lc)]
+extern crate aws_lc_sys;
 #[cfg(link_libnghttp2)]
 extern crate libnghttp2_sys;
 #[cfg(link_libz)]
 extern crate libz_sys;
+#[cfg(link_libnghttp3)]
+extern crate nghttp3_sys;
+#[cfg(link_libngtcp2)]
+extern crate ngtcp2_sys;
 #[cfg(link_openssl)]
 extern crate openssl_sys;
 #[cfg(feature = "rustls")]

--- a/tests/protocols.rs
+++ b/tests/protocols.rs
@@ -17,3 +17,11 @@ fn static_with_ftp_enabled() {
         .next()
         .is_some());
 }
+
+#[cfg(feature = "http3")]
+#[test]
+fn with_http3_enabled() {
+    let version = curl::Version::get();
+    assert!(version.feature_http3());
+    assert!(version.quic_version().is_some());
+}


### PR DESCRIPTION
Adds an `http3` feature to curl-sys that builds/links libcurl against the ngtcp2 and nghttp3 backends.

libcurl no longer marks HTTP/3 via ngtcp2/nghttp3 as "EXPERIMENTAL" (<https://curl.se/docs/http3.html>), unlike its quiche implementation, so this seemed like a good time to add it.

I used the ngtcp2 and nghttp3 bindings from the trusted [http3 crate](https://github.com/0x676e67/http3), which is maintained by people that work on hyperium.
